### PR TITLE
Fixes for the Claims Setup tool

### DIFF
--- a/Solutions/Marain.Claims.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/ClaimsServiceCollectionExtensions.cs
+++ b/Solutions/Marain.Claims.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/ClaimsServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
 #if DEBUG
             services.AddClaimsProviderStrategy<UnsafeJwtAuthorizationBearerTokenStrategy>();
+            services.AddClaimsProviderStrategy<MarainClaimsStrategy>();
 #endif
 
             services.AddClaimsProviderStrategy<EasyAuthJwtStrategy>();

--- a/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain/Claims/OpenApi/MarainClaimsStrategy.cs
+++ b/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain/Claims/OpenApi/MarainClaimsStrategy.cs
@@ -10,7 +10,7 @@ namespace Marain.Claims.OpenApi
     using Microsoft.AspNetCore.Http;
 
     /// <summary>
-    /// Builds a claims identity using the serialized payload from the 'X-ENDJIN-CLAIMS' header on the request.
+    /// Builds a claims identity using the serialized payload from the 'X-MARAIN-CLAIMS' header on the request.
     /// </summary>
     /// <remarks>
     /// The 'X-ENDJIN-CLAIMS' header should be a JSON serialized <see cref="JwtPayload"/>. The 'name' claim is used

--- a/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain/Claims/OpenApi/MarainClaimsStrategy.cs
+++ b/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain/Claims/OpenApi/MarainClaimsStrategy.cs
@@ -13,7 +13,7 @@ namespace Marain.Claims.OpenApi
     /// Builds a claims identity using the serialized payload from the 'X-MARAIN-CLAIMS' header on the request.
     /// </summary>
     /// <remarks>
-    /// The 'X-ENDJIN-CLAIMS' header should be a JSON serialized <see cref="JwtPayload"/>. The 'name' claim is used
+    /// The 'X-MARAIN-CLAIMS' header should be a JSON serialized <see cref="JwtPayload"/>. The 'name' claim is used
     /// as the identity name type, and the 'roles' claim is used as the identity role type.
     /// Example serialized payload:
     /// {"name": "mike", "roles": ["admin", "editor"], "company": "endjin"}.

--- a/Solutions/Marain.Claims.SetupTool/Marain.Claims.SetupTool.csproj
+++ b/Solutions/Marain.Claims.SetupTool/Marain.Claims.SetupTool.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
     <PackageDescription></PackageDescription>
     <PackageTags></PackageTags>
@@ -13,10 +9,8 @@
     <PackAsTool>True</PackAsTool>
   </PropertyGroup>
 
-  <Import Project="..\Common.NetStandard_2_0.proj" />
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/Solutions/Marain.Claims.SetupTool/Marain/Claims/SetupTool/AuthenticationOptions.cs
+++ b/Solutions/Marain.Claims.SetupTool/Marain/Claims/SetupTool/AuthenticationOptions.cs
@@ -157,7 +157,7 @@ namespace Marain.Claims.SetupTool
                 azureServiceTokenProviderConnectionString = "RunAs=Developer; DeveloperTool=AzureCLI";
             }
 
-            return new AuthenticationOptions(azureServiceTokenProviderConnectionString, tenantId);
+            return new AuthenticationOptions(tenantId, azureServiceTokenProviderConnectionString);
         }
 
         /// <summary>

--- a/Solutions/Marain.Claims.SetupTool/Marain/Claims/SetupTool/Commands/BootstrapClaimsTenant.cs
+++ b/Solutions/Marain.Claims.SetupTool/Marain/Claims/SetupTool/Commands/BootstrapClaimsTenant.cs
@@ -38,7 +38,7 @@ namespace Marain.Claims.SetupTool.Commands
         public string ClaimsAppId { get; set; }
 
         /// <summary>
-        /// Gets or sets the admin role name.
+        /// Gets or sets the claims service URL
         /// </summary>
         [Option(Description = "The base URL for the Claims Service", LongName = "claimsServiceUrl", ShortName = "u")]
         public string ClaimsServiceUrl { get; set; }
@@ -85,6 +85,7 @@ namespace Marain.Claims.SetupTool.Commands
 
             ServiceClientCredentials credentials = await authenticationOptions.GetServiceClientCredentialsFromKeyVault(
                 this.ClaimsAppId, this.KeyVault, this.SecretName).ConfigureAwait(false);
+
             using (var claimsClient = new ClaimsService(new Uri(this.ClaimsServiceUrl), credentials))
             {
                 try

--- a/Solutions/Marain.Claims.SetupTool/Marain/Claims/SetupTool/Commands/BootstrapClaimsTenant.cs
+++ b/Solutions/Marain.Claims.SetupTool/Marain/Claims/SetupTool/Commands/BootstrapClaimsTenant.cs
@@ -79,14 +79,32 @@ namespace Marain.Claims.SetupTool.Commands
         [Option(Description = "Authenticate using the token last fetched by the 'az' CLI", LongName = "devAzCliAuth", ShortName = "d")]
         public bool UseAzCliDevAuth { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value used for roles in X-MARAIN-CLAIMS header.
+        /// </summary>
+        [Option(Description = "Used for when running against a local debug instance of Claims. Will send X-MARAIN-CLAIMS header with {\"roles\":[\"<this-value>\"]} to authenticate, instead of using OAuth2.", LongName = "marainClaimsHeaderValue", ShortName = "x")]
+        public string MarainClaimsHeaderRoleValue { get; set; }
+
         private async Task<int> OnExecuteAsync(CommandLineApplication app, CancellationToken cancellationToken = default)
         {
-            var authenticationOptions = AuthenticationOptions.BuildFrom(this.UseAzCliDevAuth, this.TenantId);
+            ClaimsService claimsClient;
 
-            ServiceClientCredentials credentials = await authenticationOptions.GetServiceClientCredentialsFromKeyVault(
-                this.ClaimsAppId, this.KeyVault, this.SecretName).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(this.MarainClaimsHeaderRoleValue))
+            {
+                var authenticationOptions = AuthenticationOptions.BuildFrom(this.UseAzCliDevAuth, this.TenantId);
 
-            using (var claimsClient = new ClaimsService(new Uri(this.ClaimsServiceUrl), credentials))
+                ServiceClientCredentials credentials = await authenticationOptions.GetServiceClientCredentialsFromKeyVault(
+                    this.ClaimsAppId, this.KeyVault, this.SecretName).ConfigureAwait(false);
+
+                claimsClient = new ClaimsService(new Uri(this.ClaimsServiceUrl), credentials);
+            }
+            else
+            {
+                claimsClient = new ClaimsService(new Uri(this.ClaimsServiceUrl), new BasicAuthenticationCredentials());
+                claimsClient.HttpClient.DefaultRequestHeaders.Add("X-MARAIN-CLAIMS", $"{{ \"roles\": [ \"{this.MarainClaimsHeaderRoleValue}\" ] }}");
+            }
+
+            using (claimsClient)
             {
                 try
                 {


### PR DESCRIPTION
- Update tool to netcore3.1
- Fix parameter order when using `AuthenticationOptions` constructor
- Fix `ClaimsServiceUrl` property documentation
- Adds option for running the setup tool locally, without authenticating via AAD