### PR TITLE
Fixes to ensure packaging is working correctly

### DIFF
--- a/Solutions/Marain.Claims.Abstractions/Marain.Claims.Abstractions.csproj
+++ b/Solutions/Marain.Claims.Abstractions/Marain.Claims.Abstractions.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Tenancy.Abstractions" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Benchmark/Marain.Claims.Benchmark.csproj
+++ b/Solutions/Marain.Claims.Benchmark/Marain.Claims.Benchmark.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Claims.Client.OpenApi/Marain.Claims.Client.OpenApi.csproj
+++ b/Solutions/Marain.Claims.Client.OpenApi/Marain.Claims.Client.OpenApi.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Client/Marain.Claims.Client.csproj
+++ b/Solutions/Marain.Claims.Client/Marain.Claims.Client.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Host.Functions/Marain.Claims.Host.Functions.csproj
+++ b/Solutions/Marain.Claims.Host.Functions/Marain.Claims.Host.Functions.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Hosting.AspNetCore/Marain.Claims.Hosting.AspNetCore.csproj
+++ b/Solutions/Marain.Claims.Hosting.AspNetCore/Marain.Claims.Hosting.AspNetCore.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.0" />
     <PackageReference Include="Corvus.Tenancy.Abstractions" Version="1.0.0" />
     <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain.Claims.OpenApi.AspNetCore.csproj
+++ b/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain.Claims.OpenApi.AspNetCore.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.ContentHandling.Json" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.OpenApi.Service/Marain.Claims.OpenApi.Service.csproj
+++ b/Solutions/Marain.Claims.OpenApi.Service/Marain.Claims.OpenApi.Service.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.OpenApi/Marain.Claims.OpenApi.csproj
+++ b/Solutions/Marain.Claims.OpenApi/Marain.Claims.OpenApi.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.SetupTool/Marain.Claims.SetupTool.csproj
+++ b/Solutions/Marain.Claims.SetupTool/Marain.Claims.SetupTool.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Specs/Marain.Claims.Specs.csproj
+++ b/Solutions/Marain.Claims.Specs/Marain.Claims.Specs.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.7.0-preview.27" />
     <PackageReference Include="Corvus.Testing.SpecFlow" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Storage.AzureBlob/Marain.Claims.Storage.AzureBlob.csproj
+++ b/Solutions/Marain.Claims.Storage.AzureBlob/Marain.Claims.Storage.AzureBlob.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Corvus.Extensions" Version="1.0.0" />
     <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.Tenancy.AzureBlob/Marain.Claims.Tenancy.AzureBlob.csproj
+++ b/Solutions/Marain.Claims.Tenancy.AzureBlob/Marain.Claims.Tenancy.AzureBlob.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.0.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.0.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Claims.sln
+++ b/Solutions/Marain.Claims.sln
@@ -36,7 +36,7 @@ Project("{151D2E53-A2C4-4D7D-83FE-D05416EBD58E}") = "Marain.Claims.Deployment", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.SetupTool", "Marain.Claims.SetupTool\Marain.Claims.SetupTool.csproj", "{B5914684-AC2B-4234-9FA9-05C693860D5C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marain.Claims.Client.OpenApi", "Marain.Claims.Client.OpenApi\Marain.Claims.Client.OpenApi.csproj", "{CFD6C579-BCDE-4B83-AC59-1BB01E11C2CD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.Client.OpenApi", "Marain.Claims.Client.OpenApi\Marain.Claims.Client.OpenApi.csproj", "{CFD6C579-BCDE-4B83-AC59-1BB01E11C2CD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.Benchmark", "Marain.Claims.Benchmark\Marain.Claims.Benchmark.csproj", "{A4439DE9-66E5-4A43-BAA5-1609E0B0DCA3}"
 EndProject


### PR DESCRIPTION
- Updated Endjin.RecommendedPractices.NuGet to latest version, which includes fix for documentation files, which in turn fixes the `dotnet pack` issue
- Disable packaging for Marain.Claims.Benchmark