### PR TITLE
Add alternative OID claim name when building list of OIDs

### DIFF
--- a/Solutions/Marain.Claims.Abstractions/Marain/Claims/ClaimTypes.cs
+++ b/Solutions/Marain.Claims.Abstractions/Marain/Claims/ClaimTypes.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="ClaimTypes.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Marain.Claims
+{
+    /// <summary>
+    /// Constants for well-known claim types.
+    /// </summary>
+    public static class ClaimTypes
+    {
+        /// <summary>
+        /// 'oid' claim type.
+        /// </summary>
+        public const string Oid = "oid";
+
+        /// <summary>
+        /// 'http://schemas.microsoft.com/identity/claims/objectidentifier' claim type.
+        /// </summary>
+        public const string ObjectIdentifier = "http://schemas.microsoft.com/identity/claims/objectidentifier";
+    }
+}

--- a/Solutions/Marain.Claims.OpenApi.Service/Marain/Claims/OpenApi/ClaimPermissionsService.cs
+++ b/Solutions/Marain.Claims.OpenApi.Service/Marain/Claims/OpenApi/ClaimPermissionsService.cs
@@ -632,7 +632,8 @@ namespace Marain.Claims.OpenApi
                 }
                 else
                 {
-                    administratorPrincipalObjectId = context.CurrentPrincipal.FindFirst("oid").Value;
+                    administratorPrincipalObjectId =
+                        (context.CurrentPrincipal.FindFirst(ClaimTypes.Oid) ?? context.CurrentPrincipal.FindFirst(ClaimTypes.ObjectIdentifier)).Value;
                 }
 
                 var permissions = new ClaimPermissions

--- a/Solutions/Marain.Claims.OpenApi/Marain/Claims/OpenApi/Internal/IdentityBasedResourceAccessSubmissionBuilder.cs
+++ b/Solutions/Marain.Claims.OpenApi/Marain/Claims/OpenApi/Internal/IdentityBasedResourceAccessSubmissionBuilder.cs
@@ -31,7 +31,7 @@ namespace Marain.Claims.OpenApi.Internal
             // Get the list of oids for the user.
             IList<string> oids = context.CurrentPrincipal
                 .Claims
-                .Where(c => c.Type == "oid")
+                .Where(c => c.Type == "oid" || c.Type == "http://schemas.microsoft.com/identity/claims/objectidentifier")
                 .Select(c => c.Value)
                 .ToList();
 

--- a/Solutions/Marain.Claims.OpenApi/Marain/Claims/OpenApi/Internal/IdentityBasedResourceAccessSubmissionBuilder.cs
+++ b/Solutions/Marain.Claims.OpenApi/Marain/Claims/OpenApi/Internal/IdentityBasedResourceAccessSubmissionBuilder.cs
@@ -31,7 +31,7 @@ namespace Marain.Claims.OpenApi.Internal
             // Get the list of oids for the user.
             IList<string> oids = context.CurrentPrincipal
                 .Claims
-                .Where(c => c.Type == "oid" || c.Type == "http://schemas.microsoft.com/identity/claims/objectidentifier")
+                .Where(c => c.Type == Claims.ClaimTypes.Oid || c.Type == Claims.ClaimTypes.ObjectIdentifier)
                 .Select(c => c.Value)
                 .ToList();
 

--- a/Solutions/Marain.Claims.Specs/Steps/OpenApiAccessControlPolicySteps.cs
+++ b/Solutions/Marain.Claims.Specs/Steps/OpenApiAccessControlPolicySteps.cs
@@ -73,7 +73,7 @@ namespace Marain.Claims.Specs.Steps
             var identity = new ClaimsIdentity("SuperSecureTm");
             for (int i = 0; i < oidCount; ++i)
             {
-                identity.AddClaim(new Claim("oid", GetClaimPermissionsId(i)));
+                identity.AddClaim(new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", GetClaimPermissionsId(i)));
             }
 
             this.claimsPrincipal = new ClaimsPrincipal(identity);

--- a/Solutions/Marain.Claims.Specs/Steps/OpenApiAccessControlPolicySteps.cs
+++ b/Solutions/Marain.Claims.Specs/Steps/OpenApiAccessControlPolicySteps.cs
@@ -73,7 +73,7 @@ namespace Marain.Claims.Specs.Steps
             var identity = new ClaimsIdentity("SuperSecureTm");
             for (int i = 0; i < oidCount; ++i)
             {
-                identity.AddClaim(new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", GetClaimPermissionsId(i)));
+                identity.AddClaim(new Claim(Claims.ClaimTypes.ObjectIdentifier, GetClaimPermissionsId(i)));
             }
 
             this.claimsPrincipal = new ClaimsPrincipal(identity);


### PR DESCRIPTION
When using EasyAuth, the name for the OID claim is given as 'http://schemas.microsoft.com/identity/claims/objectidentifier' instead of simply 'oid', so we check for either.