### PR TITLE
Fix incorrect 'required' property on Resource in OpenAPI definition

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,5 +4,5 @@ branches:
     regex: ^master
     tag: preview
     increment: patch
-next-version: "1.2"
+next-version: "2.0"
 

--- a/Solutions/Marain.Claims.Client/Marain/Claims/Client/Models/Resource.cs
+++ b/Solutions/Marain.Claims.Client/Marain/Claims/Client/Models/Resource.cs
@@ -23,10 +23,10 @@ namespace Marain.Claims.Client.Models
         /// <summary>
         /// Initializes a new instance of the Resource class.
         /// </summary>
-        public Resource(string displayName, string uri = default(string))
+        public Resource(string displayName, string uri)
         {
-            Uri = uri;
             DisplayName = displayName;
+            Uri = uri;
             CustomInit();
         }
 
@@ -37,13 +37,13 @@ namespace Marain.Claims.Client.Models
 
         /// <summary>
         /// </summary>
-        [JsonProperty(PropertyName = "uri")]
-        public string Uri { get; set; }
+        [JsonProperty(PropertyName = "displayName")]
+        public string DisplayName { get; set; }
 
         /// <summary>
         /// </summary>
-        [JsonProperty(PropertyName = "displayName")]
-        public string DisplayName { get; set; }
+        [JsonProperty(PropertyName = "uri")]
+        public string Uri { get; set; }
 
         /// <summary>
         /// Validate the object.
@@ -56,6 +56,10 @@ namespace Marain.Claims.Client.Models
             if (DisplayName == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "DisplayName");
+            }
+            if (Uri == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "Uri");
             }
         }
     }

--- a/Solutions/Marain.Claims.OpenApi.Service/Marain/Claims/OpenApi/ClaimsServices.yaml
+++ b/Solutions/Marain.Claims.OpenApi.Service/Marain/Claims/OpenApi/ClaimsServices.yaml
@@ -430,14 +430,14 @@ components:
     Resource:
       type: object
       properties:
+        displayName:
+          type: string
         uri:
           type: string
           format: url
-        displayName:
-          type: string
       required:
-        - name
         - displayName
+        - uri
         
     ResourceAccessRule:
       type: object

--- a/Solutions/Marain.Claims.sln
+++ b/Solutions/Marain.Claims.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DevOps", "DevOps", "{D29CABE7-467E-4CF6-B44B-3C58AB76145A}"
 	ProjectSection(SolutionItems) = preProject
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
+		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.Specs", "Marain.Claims.Specs\Marain.Claims.Specs.csproj", "{CEC3DC44-36AF-4B82-B483-04AA9B3C5479}"
@@ -40,7 +41,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.Benchmark", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.Deployment", "Marain.Claims.Deployment\Marain.Claims.Deployment.csproj", "{ED0B5B20-B4A1-434B-84BB-419B87F92F80}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marain.Claims.OpenApi.Specs", "Marain.Claims.OpenApi.Specs\Marain.Claims.OpenApi.Specs.csproj", "{80C31873-7276-4A6C-ACBC-6952AECB6535}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Marain.Claims.OpenApi.Specs", "Marain.Claims.OpenApi.Specs\Marain.Claims.OpenApi.Specs.csproj", "{80C31873-7276-4A6C-ACBC-6952AECB6535}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
We were incorrectly setting `name` instead of `uri` in the 'required' properties for `Resource`. This was causing issues as `uri` is actually required, and not setting it causes issue further down the line.

This has been fixed and the client model has been regenerated. Additionally, `displayName` and `uri` order have been swapped in the OpenAPI definition so that the constructor parameter order does not change in the C# model, which may have caused issues for downstream consumers, since both parameters are strings and the change may not have been noticed.

Next version has been updated to 2.0 to reflect the breaking change in the API.