### PR TITLE
Put well-known service tenant id in template

### DIFF
--- a/Solutions/Marain.Claims.Host.Functions/local.settings.template.json
+++ b/Solutions/Marain.Claims.Host.Functions/local.settings.template.json
@@ -7,7 +7,7 @@
     "APPINSIGHTS_INSTRUMENTATIONKEY": "",
     "AI:DeveloperMode": "true",
 
-    "MarainServiceConfiguration:ServiceTenantId": "",
+    "MarainServiceConfiguration:ServiceTenantId": "3633754ac4c9be44b55bfe791b1780f1ca7153e8fbe1b54b9f44002217f1c51c",
     "MarainServiceConfiguration:ServiceDisplayName": "Claims v1",
 
     // If running with a local tenancy service, point TenancyClient:TenancyServiceBaseUri at the localhost address for that


### PR DESCRIPTION
This should always be the same, since it's a well-known tenant ID. So intead of making people find out what it is every time, it just belongs in the template settings file.