### PR TITLE
Remove duplicate claim permissions retrieval in ClaimPermissionsStore.GetBatchAsync method

### DIFF
--- a/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature
+++ b/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature
@@ -43,6 +43,18 @@ Scenario: Retrieving a batch of claim permissions from the repository
 	| claimpermissions-2 | rulesets-single  |
 
 @useChildObjects
+Scenario: Retrieving a batch of claim permissions from the repository with duplicate claim permission Ids
+	When I request a batch of claim permissions by Id from the claim permissions store
+	| ClaimPermissionsId |
+	| claimpermissions-1 |
+	| claimpermissions-1 |
+	Then the claim permissions are returned
+	And the resource access rulesets on the claim permissions match the expected rulesets
+	| ClaimPermissionsId | ExpectedRulesets |
+	| claimpermissions-1 | rulesets         |
+	| claimpermissions-1 | rulesets         |
+
+@useChildObjects
 Scenario: Retrieving claim permissions with an invalid Id
 	And an id exists named "incorrectid" but there is no claims permission associated with it
 	When I request the claim permission with Id "incorrectid" from the claim permissions store

--- a/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature
+++ b/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature
@@ -14,9 +14,13 @@ Background:
 	| Id         | DisplayName | Rules     |
 	| rulesets-1 | Ruleset 1   | {rules-1} |
 	| rulesets-2 | Ruleset 2   | {rules-2} |
+	And I have resource access rulesets called "rulesets-single"
+	| Id         | DisplayName | Rules     |
+	| rulesets-1 | Ruleset 1   | {rules-1} |
 	And I have claim permissions called "claimpermissions"
 	| Id                 | ResourceAccessRules | ResourceAccessRulesets |
 	| claimpermissions-1 |                     | {rulesets}             |
+	| claimpermissions-2 |                     | {rulesets-single}      |
 	And I have saved the resource access rulesets called "rulesets" to the resource access ruleset store
 	And I have created the claim permissions called "claimpermissions" in the claim permissions store
 
@@ -25,6 +29,18 @@ Scenario: Retrieving claim permissions from the repository
 	When I request the claim permission with Id "claimpermissions-1" from the claim permissions store
 	Then the claim permission is returned
 	And the resource access rulesets on the claim permission match the rulesets "rulesets"
+
+@useChildObjects
+Scenario: Retrieving a batch of claim permissions from the repository
+	When I request a batch of claim permissions by Id from the claim permissions store
+	| ClaimPermissionsId |
+	| claimpermissions-1 |
+	| claimpermissions-2 |
+	Then the claim permissions are returned
+	And the resource access rulesets on the claim permissions match the expected rulesets
+	| ClaimPermissionsId | ExpectedRulesets |
+	| claimpermissions-1 | rulesets         |
+	| claimpermissions-2 | rulesets-single  |
 
 @useChildObjects
 Scenario: Retrieving claim permissions with an invalid Id

--- a/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature
+++ b/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature
@@ -43,7 +43,7 @@ Scenario: Retrieving a batch of claim permissions from the repository
 	| claimpermissions-2 | rulesets-single  |
 
 @useChildObjects
-Scenario: Retrieving a batch of claim permissions from the repository with duplicate claim permission Ids
+Scenario: Retrieving a batch of claim permissions from the repository with duplicate claim permission Ids automatically deduplicates the requests
 	When I request a batch of claim permissions by Id from the claim permissions store
 	| ClaimPermissionsId |
 	| claimpermissions-1 |
@@ -51,7 +51,6 @@ Scenario: Retrieving a batch of claim permissions from the repository with dupli
 	Then the claim permissions are returned
 	And the resource access rulesets on the claim permissions match the expected rulesets
 	| ClaimPermissionsId | ExpectedRulesets |
-	| claimpermissions-1 | rulesets         |
 	| claimpermissions-1 | rulesets         |
 
 @useChildObjects

--- a/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature.cs
@@ -266,15 +266,15 @@ this.FeatureBackground();
         
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Retrieving a batch of claim permissions from the repository with duplicate claim " +
-            "permission Ids")]
+            "permission Ids automatically deduplicates the requests")]
         [NUnit.Framework.CategoryAttribute("useChildObjects")]
-        public virtual void RetrievingABatchOfClaimPermissionsFromTheRepositoryWithDuplicateClaimPermissionIds()
+        public virtual void RetrievingABatchOfClaimPermissionsFromTheRepositoryWithDuplicateClaimPermissionIdsAutomaticallyDeduplicatesTheRequests()
         {
             string[] tagsOfScenario = new string[] {
                     "useChildObjects"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving a batch of claim permissions from the repository with duplicate claim " +
-                    "permission Ids", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+                    "permission Ids automatically deduplicates the requests", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
 #line 46
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -316,9 +316,6 @@ this.FeatureBackground();
                 table10.AddRow(new string[] {
                             "claimpermissions-1",
                             "rulesets"});
-                table10.AddRow(new string[] {
-                            "claimpermissions-1",
-                            "rulesets"});
 #line 52
  testRunner.And("the resource access rulesets on the claim permissions match the expected rulesets" +
                         "", ((string)(null)), table10, "And ");
@@ -336,7 +333,7 @@ this.FeatureBackground();
                     "useChildObjects"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions with an invalid Id", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 58
+#line 57
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -359,15 +356,15 @@ this.ScenarioInitialize(scenarioInfo);
 #line 6
 this.FeatureBackground();
 #line hidden
-#line 59
+#line 58
  testRunner.And("an id exists named \"incorrectid\" but there is no claims permission associated wit" +
                         "h it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 60
+#line 59
  testRunner.When("I request the claim permission with Id \"incorrectid\" from the claim permissions s" +
                         "tore", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 61
+#line 60
  testRunner.Then("a \"ClaimPermissionsNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -385,7 +382,7 @@ this.FeatureBackground();
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions when one or more of the referenced rule sets are mis" +
                     "sing", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 64
+#line 63
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -420,7 +417,7 @@ this.FeatureBackground();
                             "rulesets-4",
                             "Ruleset 4",
                             "{rules-2}"});
-#line 65
+#line 64
  testRunner.Given("I have resource access rulesets called \"rulesets-unsaved\"", ((string)(null)), table11, "Given ");
 #line hidden
                 TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
@@ -431,18 +428,18 @@ this.FeatureBackground();
                             "claimpermissions-2",
                             "",
                             "{rulesets-unsaved}"});
-#line 69
+#line 68
  testRunner.And("I have claim permissions called \"claimpermissions-2\"", ((string)(null)), table12, "And ");
 #line hidden
-#line 72
+#line 71
  testRunner.And("I have created the claim permissions called \"claimpermissions-2\" in the claim per" +
                         "missions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 73
+#line 72
  testRunner.When("I request the claim permission with Id \"claimpermissions-2\" from the claim permis" +
                         "sions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 74
+#line 73
  testRunner.Then("a \"ResourceAccessRuleSetNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }

--- a/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature.cs
@@ -265,14 +265,16 @@ this.FeatureBackground();
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Retrieving claim permissions with an invalid Id")]
+        [NUnit.Framework.DescriptionAttribute("Retrieving a batch of claim permissions from the repository with duplicate claim " +
+            "permission Ids")]
         [NUnit.Framework.CategoryAttribute("useChildObjects")]
-        public virtual void RetrievingClaimPermissionsWithAnInvalidId()
+        public virtual void RetrievingABatchOfClaimPermissionsFromTheRepositoryWithDuplicateClaimPermissionIds()
         {
             string[] tagsOfScenario = new string[] {
                     "useChildObjects"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions with an invalid Id", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving a batch of claim permissions from the repository with duplicate claim " +
+                    "permission Ids", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
 #line 46
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -296,33 +298,45 @@ this.ScenarioInitialize(scenarioInfo);
 #line 6
 this.FeatureBackground();
 #line hidden
+                TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
+                            "ClaimPermissionsId"});
+                table9.AddRow(new string[] {
+                            "claimpermissions-1"});
+                table9.AddRow(new string[] {
+                            "claimpermissions-1"});
 #line 47
- testRunner.And("an id exists named \"incorrectid\" but there is no claims permission associated wit" +
-                        "h it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.When("I request a batch of claim permissions by Id from the claim permissions store", ((string)(null)), table9, "When ");
 #line hidden
-#line 48
- testRunner.When("I request the claim permission with Id \"incorrectid\" from the claim permissions s" +
-                        "tore", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 51
+ testRunner.Then("the claim permissions are returned", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 49
- testRunner.Then("a \"ClaimPermissionsNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+                TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
+                            "ClaimPermissionsId",
+                            "ExpectedRulesets"});
+                table10.AddRow(new string[] {
+                            "claimpermissions-1",
+                            "rulesets"});
+                table10.AddRow(new string[] {
+                            "claimpermissions-1",
+                            "rulesets"});
+#line 52
+ testRunner.And("the resource access rulesets on the claim permissions match the expected rulesets" +
+                        "", ((string)(null)), table10, "And ");
 #line hidden
             }
             this.ScenarioCleanup();
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Retrieving claim permissions when one or more of the referenced rule sets are mis" +
-            "sing")]
+        [NUnit.Framework.DescriptionAttribute("Retrieving claim permissions with an invalid Id")]
         [NUnit.Framework.CategoryAttribute("useChildObjects")]
-        public virtual void RetrievingClaimPermissionsWhenOneOrMoreOfTheReferencedRuleSetsAreMissing()
+        public virtual void RetrievingClaimPermissionsWithAnInvalidId()
         {
             string[] tagsOfScenario = new string[] {
                     "useChildObjects"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions when one or more of the referenced rule sets are mis" +
-                    "sing", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 52
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions with an invalid Id", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+#line 58
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -345,41 +359,90 @@ this.ScenarioInitialize(scenarioInfo);
 #line 6
 this.FeatureBackground();
 #line hidden
-                TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
+#line 59
+ testRunner.And("an id exists named \"incorrectid\" but there is no claims permission associated wit" +
+                        "h it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 60
+ testRunner.When("I request the claim permission with Id \"incorrectid\" from the claim permissions s" +
+                        "tore", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 61
+ testRunner.Then("a \"ClaimPermissionsNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Retrieving claim permissions when one or more of the referenced rule sets are mis" +
+            "sing")]
+        [NUnit.Framework.CategoryAttribute("useChildObjects")]
+        public virtual void RetrievingClaimPermissionsWhenOneOrMoreOfTheReferencedRuleSetsAreMissing()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "useChildObjects"};
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions when one or more of the referenced rule sets are mis" +
+                    "sing", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+#line 64
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 6
+this.FeatureBackground();
+#line hidden
+                TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
                             "Id",
                             "DisplayName",
                             "Rules"});
-                table9.AddRow(new string[] {
+                table11.AddRow(new string[] {
                             "rulesets-3",
                             "Ruleset 3",
                             "{rules-1}"});
-                table9.AddRow(new string[] {
+                table11.AddRow(new string[] {
                             "rulesets-4",
                             "Ruleset 4",
                             "{rules-2}"});
-#line 53
- testRunner.Given("I have resource access rulesets called \"rulesets-unsaved\"", ((string)(null)), table9, "Given ");
+#line 65
+ testRunner.Given("I have resource access rulesets called \"rulesets-unsaved\"", ((string)(null)), table11, "Given ");
 #line hidden
-                TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
                             "Id",
                             "ResourceAccessRules",
                             "ResourceAccessRulesets"});
-                table10.AddRow(new string[] {
+                table12.AddRow(new string[] {
                             "claimpermissions-2",
                             "",
                             "{rulesets-unsaved}"});
-#line 57
- testRunner.And("I have claim permissions called \"claimpermissions-2\"", ((string)(null)), table10, "And ");
+#line 69
+ testRunner.And("I have claim permissions called \"claimpermissions-2\"", ((string)(null)), table12, "And ");
 #line hidden
-#line 60
+#line 72
  testRunner.And("I have created the claim permissions called \"claimpermissions-2\" in the claim per" +
                         "missions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 61
+#line 73
  testRunner.When("I request the claim permission with Id \"claimpermissions-2\" from the claim permis" +
                         "sions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 62
+#line 74
  testRunner.Then("a \"ResourceAccessRuleSetNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }

--- a/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/ClaimPermissionsStore.feature.cs
@@ -122,20 +122,35 @@ namespace Marain.Claims.Specs.Features
 #line hidden
             TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
                         "Id",
+                        "DisplayName",
+                        "Rules"});
+            table5.AddRow(new string[] {
+                        "rulesets-1",
+                        "Ruleset 1",
+                        "{rules-1}"});
+#line 17
+ testRunner.And("I have resource access rulesets called \"rulesets-single\"", ((string)(null)), table5, "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
+                        "Id",
                         "ResourceAccessRules",
                         "ResourceAccessRulesets"});
-            table5.AddRow(new string[] {
+            table6.AddRow(new string[] {
                         "claimpermissions-1",
                         "",
                         "{rulesets}"});
-#line 17
- testRunner.And("I have claim permissions called \"claimpermissions\"", ((string)(null)), table5, "And ");
-#line hidden
+            table6.AddRow(new string[] {
+                        "claimpermissions-2",
+                        "",
+                        "{rulesets-single}"});
 #line 20
+ testRunner.And("I have claim permissions called \"claimpermissions\"", ((string)(null)), table6, "And ");
+#line hidden
+#line 24
  testRunner.And("I have saved the resource access rulesets called \"rulesets\" to the resource acces" +
                     "s ruleset store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 21
+#line 25
  testRunner.And("I have created the claim permissions called \"claimpermissions\" in the claim permi" +
                     "ssions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -150,7 +165,7 @@ namespace Marain.Claims.Specs.Features
                     "useChildObjects"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions from the repository", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 24
+#line 28
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -173,16 +188,77 @@ this.ScenarioInitialize(scenarioInfo);
 #line 6
 this.FeatureBackground();
 #line hidden
-#line 25
+#line 29
  testRunner.When("I request the claim permission with Id \"claimpermissions-1\" from the claim permis" +
                         "sions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 26
+#line 30
  testRunner.Then("the claim permission is returned", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 27
+#line 31
  testRunner.And("the resource access rulesets on the claim permission match the rulesets \"rulesets" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Retrieving a batch of claim permissions from the repository")]
+        [NUnit.Framework.CategoryAttribute("useChildObjects")]
+        public virtual void RetrievingABatchOfClaimPermissionsFromTheRepository()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "useChildObjects"};
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving a batch of claim permissions from the repository", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+#line 34
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 6
+this.FeatureBackground();
+#line hidden
+                TechTalk.SpecFlow.Table table7 = new TechTalk.SpecFlow.Table(new string[] {
+                            "ClaimPermissionsId"});
+                table7.AddRow(new string[] {
+                            "claimpermissions-1"});
+                table7.AddRow(new string[] {
+                            "claimpermissions-2"});
+#line 35
+ testRunner.When("I request a batch of claim permissions by Id from the claim permissions store", ((string)(null)), table7, "When ");
+#line hidden
+#line 39
+ testRunner.Then("the claim permissions are returned", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+                TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
+                            "ClaimPermissionsId",
+                            "ExpectedRulesets"});
+                table8.AddRow(new string[] {
+                            "claimpermissions-1",
+                            "rulesets"});
+                table8.AddRow(new string[] {
+                            "claimpermissions-2",
+                            "rulesets-single"});
+#line 40
+ testRunner.And("the resource access rulesets on the claim permissions match the expected rulesets" +
+                        "", ((string)(null)), table8, "And ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -197,7 +273,7 @@ this.FeatureBackground();
                     "useChildObjects"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions with an invalid Id", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 30
+#line 46
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -220,15 +296,15 @@ this.ScenarioInitialize(scenarioInfo);
 #line 6
 this.FeatureBackground();
 #line hidden
-#line 31
+#line 47
  testRunner.And("an id exists named \"incorrectid\" but there is no claims permission associated wit" +
                         "h it", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 32
+#line 48
  testRunner.When("I request the claim permission with Id \"incorrectid\" from the claim permissions s" +
                         "tore", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 33
+#line 49
  testRunner.Then("a \"ClaimPermissionsNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }
@@ -246,7 +322,7 @@ this.FeatureBackground();
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Retrieving claim permissions when one or more of the referenced rule sets are mis" +
                     "sing", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 36
+#line 52
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -269,41 +345,41 @@ this.ScenarioInitialize(scenarioInfo);
 #line 6
 this.FeatureBackground();
 #line hidden
-                TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
                             "Id",
                             "DisplayName",
                             "Rules"});
-                table6.AddRow(new string[] {
+                table9.AddRow(new string[] {
                             "rulesets-3",
                             "Ruleset 3",
                             "{rules-1}"});
-                table6.AddRow(new string[] {
+                table9.AddRow(new string[] {
                             "rulesets-4",
                             "Ruleset 4",
                             "{rules-2}"});
-#line 37
- testRunner.Given("I have resource access rulesets called \"rulesets-unsaved\"", ((string)(null)), table6, "Given ");
+#line 53
+ testRunner.Given("I have resource access rulesets called \"rulesets-unsaved\"", ((string)(null)), table9, "Given ");
 #line hidden
-                TechTalk.SpecFlow.Table table7 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
                             "Id",
                             "ResourceAccessRules",
                             "ResourceAccessRulesets"});
-                table7.AddRow(new string[] {
+                table10.AddRow(new string[] {
                             "claimpermissions-2",
                             "",
                             "{rulesets-unsaved}"});
-#line 41
- testRunner.And("I have claim permissions called \"claimpermissions-2\"", ((string)(null)), table7, "And ");
+#line 57
+ testRunner.And("I have claim permissions called \"claimpermissions-2\"", ((string)(null)), table10, "And ");
 #line hidden
-#line 44
+#line 60
  testRunner.And("I have created the claim permissions called \"claimpermissions-2\" in the claim per" +
                         "missions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 45
+#line 61
  testRunner.When("I request the claim permission with Id \"claimpermissions-2\" from the claim permis" +
                         "sions store", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 46
+#line 62
  testRunner.Then("a \"ResourceAccessRuleSetNotFoundException\" exception is thrown", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }

--- a/Solutions/Marain.Claims.Specs/Features/IdentityBasedOpenApiAccessControlPolicy.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/IdentityBasedOpenApiAccessControlPolicy.feature.cs
@@ -459,20 +459,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 69
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table11.AddRow(new string[] {
+                table13.AddRow(new string[] {
                             "0",
                             "allow"});
-                table11.AddRow(new string[] {
+                table13.AddRow(new string[] {
                             "1",
                             "allow"});
-                table11.AddRow(new string[] {
+                table13.AddRow(new string[] {
                             "2",
                             "allow"});
 #line 70
- testRunner.And("the evaluator returns the following results", ((string)(null)), table11, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table13, "And ");
 #line hidden
 #line 75
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -514,20 +514,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 79
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table12.AddRow(new string[] {
+                table14.AddRow(new string[] {
                             "0",
                             "deny"});
-                table12.AddRow(new string[] {
+                table14.AddRow(new string[] {
                             "1",
                             "deny"});
-                table12.AddRow(new string[] {
+                table14.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 80
- testRunner.And("the evaluator returns the following results", ((string)(null)), table12, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table14, "And ");
 #line hidden
 #line 85
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -571,20 +571,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 89
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table13.AddRow(new string[] {
+                table15.AddRow(new string[] {
                             "0",
                             "allow"});
-                table13.AddRow(new string[] {
+                table15.AddRow(new string[] {
                             "1",
                             "deny"});
-                table13.AddRow(new string[] {
+                table15.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 90
- testRunner.And("the evaluator returns the following results", ((string)(null)), table13, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table15, "And ");
 #line hidden
 #line 95
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -628,20 +628,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 99
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table14.AddRow(new string[] {
+                table16.AddRow(new string[] {
                             "0",
                             "allow"});
-                table14.AddRow(new string[] {
+                table16.AddRow(new string[] {
                             "1",
                             "allow"});
-                table14.AddRow(new string[] {
+                table16.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 100
- testRunner.And("the evaluator returns the following results", ((string)(null)), table14, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table16, "And ");
 #line hidden
 #line 105
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -688,20 +688,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 110
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table15.AddRow(new string[] {
+                table17.AddRow(new string[] {
                             "0",
                             "allow"});
-                table15.AddRow(new string[] {
+                table17.AddRow(new string[] {
                             "1",
                             "deny"});
-                table15.AddRow(new string[] {
+                table17.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 111
- testRunner.And("the evaluator returns the following results", ((string)(null)), table15, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table17, "And ");
 #line hidden
 #line 116
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -748,20 +748,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 121
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table16.AddRow(new string[] {
+                table18.AddRow(new string[] {
                             "0",
                             "allow"});
-                table16.AddRow(new string[] {
+                table18.AddRow(new string[] {
                             "1",
                             "allow"});
-                table16.AddRow(new string[] {
+                table18.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 122
- testRunner.And("the evaluator returns the following results", ((string)(null)), table16, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table18, "And ");
 #line hidden
 #line 127
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");

--- a/Solutions/Marain.Claims.Specs/Features/IdentityBasedOpenApiAccessControlPolicy.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/IdentityBasedOpenApiAccessControlPolicy.feature.cs
@@ -459,20 +459,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 69
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table8.AddRow(new string[] {
+                table11.AddRow(new string[] {
                             "0",
                             "allow"});
-                table8.AddRow(new string[] {
+                table11.AddRow(new string[] {
                             "1",
                             "allow"});
-                table8.AddRow(new string[] {
+                table11.AddRow(new string[] {
                             "2",
                             "allow"});
 #line 70
- testRunner.And("the evaluator returns the following results", ((string)(null)), table8, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table11, "And ");
 #line hidden
 #line 75
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -514,20 +514,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 79
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table9.AddRow(new string[] {
+                table12.AddRow(new string[] {
                             "0",
                             "deny"});
-                table9.AddRow(new string[] {
+                table12.AddRow(new string[] {
                             "1",
                             "deny"});
-                table9.AddRow(new string[] {
+                table12.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 80
- testRunner.And("the evaluator returns the following results", ((string)(null)), table9, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table12, "And ");
 #line hidden
 #line 85
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -571,20 +571,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 89
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table10.AddRow(new string[] {
+                table13.AddRow(new string[] {
                             "0",
                             "allow"});
-                table10.AddRow(new string[] {
+                table13.AddRow(new string[] {
                             "1",
                             "deny"});
-                table10.AddRow(new string[] {
+                table13.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 90
- testRunner.And("the evaluator returns the following results", ((string)(null)), table10, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table13, "And ");
 #line hidden
 #line 95
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -628,20 +628,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 99
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table11.AddRow(new string[] {
+                table14.AddRow(new string[] {
                             "0",
                             "allow"});
-                table11.AddRow(new string[] {
+                table14.AddRow(new string[] {
                             "1",
                             "allow"});
-                table11.AddRow(new string[] {
+                table14.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 100
- testRunner.And("the evaluator returns the following results", ((string)(null)), table11, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table14, "And ");
 #line hidden
 #line 105
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -688,20 +688,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 110
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table12.AddRow(new string[] {
+                table15.AddRow(new string[] {
                             "0",
                             "allow"});
-                table12.AddRow(new string[] {
+                table15.AddRow(new string[] {
                             "1",
                             "deny"});
-                table12.AddRow(new string[] {
+                table15.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 111
- testRunner.And("the evaluator returns the following results", ((string)(null)), table12, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table15, "And ");
 #line hidden
 #line 116
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -748,20 +748,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 121
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table13.AddRow(new string[] {
+                table16.AddRow(new string[] {
                             "0",
                             "allow"});
-                table13.AddRow(new string[] {
+                table16.AddRow(new string[] {
                             "1",
                             "allow"});
-                table13.AddRow(new string[] {
+                table16.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 122
- testRunner.And("the evaluator returns the following results", ((string)(null)), table13, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table16, "And ");
 #line hidden
 #line 127
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");

--- a/Solutions/Marain.Claims.Specs/Features/RoleBasedOpenApiAccessControlPolicy.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/RoleBasedOpenApiAccessControlPolicy.feature.cs
@@ -459,20 +459,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 69
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table14.AddRow(new string[] {
+                table17.AddRow(new string[] {
                             "0",
                             "allow"});
-                table14.AddRow(new string[] {
+                table17.AddRow(new string[] {
                             "1",
                             "allow"});
-                table14.AddRow(new string[] {
+                table17.AddRow(new string[] {
                             "2",
                             "allow"});
 #line 70
- testRunner.And("the evaluator returns the following results", ((string)(null)), table14, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table17, "And ");
 #line hidden
 #line 75
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -514,20 +514,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 79
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table15.AddRow(new string[] {
+                table18.AddRow(new string[] {
                             "0",
                             "deny"});
-                table15.AddRow(new string[] {
+                table18.AddRow(new string[] {
                             "1",
                             "deny"});
-                table15.AddRow(new string[] {
+                table18.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 80
- testRunner.And("the evaluator returns the following results", ((string)(null)), table15, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table18, "And ");
 #line hidden
 #line 85
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -569,20 +569,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 89
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table16.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "0",
                             "allow"});
-                table16.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "1",
                             "deny"});
-                table16.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 90
- testRunner.And("the evaluator returns the following results", ((string)(null)), table16, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table19, "And ");
 #line hidden
 #line 95
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -624,20 +624,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 99
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table20 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table17.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "0",
                             "allow"});
-                table17.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "1",
                             "allow"});
-                table17.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 100
- testRunner.And("the evaluator returns the following results", ((string)(null)), table17, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table20, "And ");
 #line hidden
 #line 105
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -684,20 +684,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 110
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table21 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table18.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "0",
                             "allow"});
-                table18.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "1",
                             "deny"});
-                table18.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 111
- testRunner.And("the evaluator returns the following results", ((string)(null)), table18, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table21, "And ");
 #line hidden
 #line 116
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -744,20 +744,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 121
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table22 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table19.AddRow(new string[] {
+                table22.AddRow(new string[] {
                             "0",
                             "allow"});
-                table19.AddRow(new string[] {
+                table22.AddRow(new string[] {
                             "1",
                             "allow"});
-                table19.AddRow(new string[] {
+                table22.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 122
- testRunner.And("the evaluator returns the following results", ((string)(null)), table19, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table22, "And ");
 #line hidden
 #line 127
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");

--- a/Solutions/Marain.Claims.Specs/Features/RoleBasedOpenApiAccessControlPolicy.feature.cs
+++ b/Solutions/Marain.Claims.Specs/Features/RoleBasedOpenApiAccessControlPolicy.feature.cs
@@ -459,20 +459,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 69
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table17.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "0",
                             "allow"});
-                table17.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "1",
                             "allow"});
-                table17.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "2",
                             "allow"});
 #line 70
- testRunner.And("the evaluator returns the following results", ((string)(null)), table17, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table19, "And ");
 #line hidden
 #line 75
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -514,20 +514,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 79
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table20 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table18.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "0",
                             "deny"});
-                table18.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "1",
                             "deny"});
-                table18.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 80
- testRunner.And("the evaluator returns the following results", ((string)(null)), table18, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table20, "And ");
 #line hidden
 #line 85
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -569,20 +569,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 89
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table21 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table19.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "0",
                             "allow"});
-                table19.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "1",
                             "deny"});
-                table19.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 90
- testRunner.And("the evaluator returns the following results", ((string)(null)), table19, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table21, "And ");
 #line hidden
 #line 95
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -624,20 +624,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 99
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table20 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table22 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table20.AddRow(new string[] {
+                table22.AddRow(new string[] {
                             "0",
                             "allow"});
-                table20.AddRow(new string[] {
+                table22.AddRow(new string[] {
                             "1",
                             "allow"});
-                table20.AddRow(new string[] {
+                table22.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 100
- testRunner.And("the evaluator returns the following results", ((string)(null)), table20, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table22, "And ");
 #line hidden
 #line 105
     testRunner.Then("the result should grant access", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -684,20 +684,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 110
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table21 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table23 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table21.AddRow(new string[] {
+                table23.AddRow(new string[] {
                             "0",
                             "allow"});
-                table21.AddRow(new string[] {
+                table23.AddRow(new string[] {
                             "1",
                             "deny"});
-                table21.AddRow(new string[] {
+                table23.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 111
- testRunner.And("the evaluator returns the following results", ((string)(null)), table21, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table23, "And ");
 #line hidden
 #line 116
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
@@ -744,20 +744,20 @@ this.ScenarioInitialize(scenarioInfo);
 #line 121
     testRunner.When("I invoke the policy with a path of \'/foo/bar\' and a method of \'GET\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-                TechTalk.SpecFlow.Table table22 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table24 = new TechTalk.SpecFlow.Table(new string[] {
                             "ClaimPermissionsId",
                             "Result"});
-                table22.AddRow(new string[] {
+                table24.AddRow(new string[] {
                             "0",
                             "allow"});
-                table22.AddRow(new string[] {
+                table24.AddRow(new string[] {
                             "1",
                             "allow"});
-                table22.AddRow(new string[] {
+                table24.AddRow(new string[] {
                             "2",
                             "deny"});
 #line 122
- testRunner.And("the evaluator returns the following results", ((string)(null)), table22, "And ");
+ testRunner.And("the evaluator returns the following results", ((string)(null)), table24, "And ");
 #line hidden
 #line 127
     testRunner.Then("the result type should be \'NotAllowed\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");

--- a/Solutions/Marain.Claims.Specs/Steps/ClaimPermissionsStoreSteps.cs
+++ b/Solutions/Marain.Claims.Specs/Steps/ClaimPermissionsStoreSteps.cs
@@ -171,6 +171,11 @@ namespace Marain.Claims.SpecFlow.Steps
         [Then("the claim permissions are returned")]
         public void ThenClaimPermissionsAreReturned()
         {
+            if (this.scenarioContext.TryGetValue(out Exception exception))
+            {
+                Assert.Fail("An exception was thrown when retrieving ClaimPermissions: " + exception.ToString());
+            }
+
             if (!this.scenarioContext.TryGetValue(ClaimPermissionsResult, out ClaimPermissionsCollection results))
             {
                 Assert.Fail("The expected result was not found in the scenario context.");
@@ -201,13 +206,15 @@ namespace Marain.Claims.SpecFlow.Steps
 
             Assert.AreEqual(table.Rows.Count, loadedClaimPermissionsBatch.Permissions.Count, "The expected number of claim permissions were not loaded");
 
-            foreach (TableRow currentRow in table.Rows)
+            for (int index = 0; index < table.Rows.Count; index++)
             {
+                TableRow currentRow = table.Rows[index];
+
                 // For each row in the "expected results", we need to:
                 // - ensure we actually got the target ClaimPermissions back in the batch
                 // - load the expected rulesets and then make sure the loaded claim permission matches.
-                ClaimPermissions loadedClaimPermissions = loadedClaimPermissionsBatch.Permissions.Find(x => x.Id == this.claimPermissionIds[currentRow[0]]);
-                Assert.NotNull(loadedClaimPermissions, $"The ClaimPermissions with Id '{currentRow[0]}' was not loaded");
+                ClaimPermissions loadedClaimPermissions = loadedClaimPermissionsBatch.Permissions[index];
+                Assert.AreEqual(this.claimPermissionIds[currentRow[0]], loadedClaimPermissions.Id);
 
                 List<ResourceAccessRuleSet> expectedRulesets = this.scenarioContext.Get<List<ResourceAccessRuleSet>>(currentRow[1]);
                 Assert.AreEqual(expectedRulesets.Count, loadedClaimPermissions.ResourceAccessRuleSets.Count, $"The loaded ClaimPermissions with Id '{loadedClaimPermissions.Id}' did not contain the expected number of ResourceAccessRulesets");

--- a/Solutions/Marain.Claims.Specs/Steps/ClaimPermissionsStoreSteps.cs
+++ b/Solutions/Marain.Claims.Specs/Steps/ClaimPermissionsStoreSteps.cs
@@ -140,10 +140,38 @@ namespace Marain.Claims.SpecFlow.Steps
             }
         }
 
+        [When("I request a batch of claim permissions by Id from the claim permissions store")]
+        public async Task WhenIRequestABatchOfClaimPermissionsByIdFromTheClaimPermissionsStore(Table table)
+        {
+            IEnumerable<string> claimIdNames = table.Rows.Select(x => x[0]);
+            IEnumerable<string> claimIds = claimIdNames.Select(x => this.claimPermissionIds[x]);
+
+            IClaimPermissionsStore store = await this.GetClaimPermissionsStoreAsync().ConfigureAwait(false);
+
+            try
+            {
+                ClaimPermissionsCollection result = await store.GetBatchAsync(claimIds).ConfigureAwait(false);
+                this.scenarioContext.Set(result, ClaimPermissionsResult);
+            }
+            catch (Exception ex)
+            {
+                this.scenarioContext.Set(ex);
+            }
+        }
+
         [Then(@"the claim permission is returned")]
         public void ThenTheClaimPermissionIsReturned()
         {
             if (!this.scenarioContext.TryGetValue(ClaimPermissionsResult, out ClaimPermissions _))
+            {
+                Assert.Fail("The expected result was not found in the scenario context.");
+            }
+        }
+
+        [Then("the claim permissions are returned")]
+        public void ThenClaimPermissionsAreReturned()
+        {
+            if (!this.scenarioContext.TryGetValue(ClaimPermissionsResult, out ClaimPermissionsCollection results))
             {
                 Assert.Fail("The expected result was not found in the scenario context.");
             }
@@ -163,6 +191,34 @@ namespace Marain.Claims.SpecFlow.Steps
 
                 Assert.NotNull(loadedRuleset, $"The loaded ClaimPermissions did not contain the expected ResourceAccessRuleset with Id '{current.Id}'");
                 Assert.That(loadedRuleset.Rules, Is.EquivalentTo(current.Rules), $"The loaded ResourceAccessRuleset with Id '{current.Id}' was not equivalent to the expected ResourceAccessRuleset");
+            }
+        }
+
+        [Then("the resource access rulesets on the claim permissions match the expected rulesets")]
+        public void ThenTheResourceAccessRulesetsOnTheClaimPermissionsMatchTheExpectedRulesets(Table table)
+        {
+            ClaimPermissionsCollection loadedClaimPermissionsBatch = this.scenarioContext.Get<ClaimPermissionsCollection>(ClaimPermissionsResult);
+
+            Assert.AreEqual(table.Rows.Count, loadedClaimPermissionsBatch.Permissions.Count, "The expected number of claim permissions were not loaded");
+
+            foreach (TableRow currentRow in table.Rows)
+            {
+                // For each row in the "expected results", we need to:
+                // - ensure we actually got the target ClaimPermissions back in the batch
+                // - load the expected rulesets and then make sure the loaded claim permission matches.
+                ClaimPermissions loadedClaimPermissions = loadedClaimPermissionsBatch.Permissions.Find(x => x.Id == this.claimPermissionIds[currentRow[0]]);
+                Assert.NotNull(loadedClaimPermissions, $"The ClaimPermissions with Id '{currentRow[0]}' was not loaded");
+
+                List<ResourceAccessRuleSet> expectedRulesets = this.scenarioContext.Get<List<ResourceAccessRuleSet>>(currentRow[1]);
+                Assert.AreEqual(expectedRulesets.Count, loadedClaimPermissions.ResourceAccessRuleSets.Count, $"The loaded ClaimPermissions with Id '{loadedClaimPermissions.Id}' did not contain the expected number of ResourceAccessRulesets");
+
+                foreach (ResourceAccessRuleSet currentRuleset in expectedRulesets)
+                {
+                    ResourceAccessRuleSet loadedRuleset = loadedClaimPermissions.ResourceAccessRuleSets.FirstOrDefault(x => x.Id == currentRuleset.Id);
+
+                    Assert.NotNull(loadedRuleset, $"The loaded ClaimPermissions did not contain the expected ResourceAccessRuleset with Id '{currentRuleset.Id}'");
+                    Assert.That(loadedRuleset.Rules, Is.EquivalentTo(currentRuleset.Rules), $"The loaded ResourceAccessRuleset with Id '{currentRuleset.Id}' was not equivalent to the expected ResourceAccessRuleset");
+                }
             }
         }
 

--- a/Solutions/Marain.Claims.Storage.AzureBlob/Marain/Claims/Storage/ClaimPermissionsStore.cs
+++ b/Solutions/Marain.Claims.Storage.AzureBlob/Marain/Claims/Storage/ClaimPermissionsStore.cs
@@ -98,7 +98,7 @@ namespace Marain.Claims.Storage
 
             var result = new ClaimPermissionsCollection();
 
-            foreach (IList<string> batch in ids.Buffer(maxParallelism))
+            foreach (IList<string> batch in ids.Distinct().Buffer(maxParallelism))
             {
                 IList<Task<ClaimPermissions>> taskBatch = batch.Select(id => Task.Run(async () =>
                 {


### PR DESCRIPTION
At present, the `GetBatchAsync` doesn't do any deduplication on the supplied list of `ClaimPermissions` Ids passed in. This has two disadvantages:
- It's inefficient, as it results in retrieving the `ClaimPermissions` document (and checking for the associated `ResourceAccessRules`) multiple times.
- If it's necessary to retrieve updated `ResourceAccessRules` for a duplicated `ClaimPermissions`, an error will be thrown. This can be seen in commit `c42e628eb0e44573b1f9d3b3b0c84dee53799863`, which adds a failing test for that scenario.

The change deduplicates the list of Ids in the `GetBatchAsync` method. It has the side effect that only distinct `ClaimPermissions` will be returned, however the only place this is used right now is in the `ClaimPermissionsService.GetClaimPermissionsPermissionBatchAsync` method, and the way that's written means that this change won't cause any issues.