### PR TITLE
Upgrade various Menes and Corvus packages

### DIFF
--- a/Solutions/Marain.Claims.Abstractions/Marain.Claims.Abstractions.csproj
+++ b/Solutions/Marain.Claims.Abstractions/Marain.Claims.Abstractions.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="1.1.1" />
+    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="2.0.13" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Menes.Abstractions" Version="1.2.1" />
+    <PackageReference Include="Menes.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="[3.1.*,)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Solutions/Marain.Claims.Benchmark/ComplexClaimsBenchmarks.cs
+++ b/Solutions/Marain.Claims.Benchmark/ComplexClaimsBenchmarks.cs
@@ -97,7 +97,7 @@
         [Benchmark]
         public Task GetClaimPermissionsResourceAccessRules() => this.ClaimsService.GetClaimPermissionsResourceAccessRulesAsync("One", this.ClientTenantId);
 
-        /// <summary>
+        /// <inheritdoc/>
         protected override async Task SetupTestDataAsync()
         {
             RulesetsAndClaimPermissions input = JsonConvert.DeserializeObject<RulesetsAndClaimPermissions>(

--- a/Solutions/Marain.Claims.Benchmark/Marain.Claims.Benchmark.csproj
+++ b/Solutions/Marain.Claims.Benchmark/Marain.Claims.Benchmark.csproj
@@ -32,8 +32,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.1.1" />
-    <PackageReference Include="Marain.Tenancy.Client" Version="1.1.11" />
+    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="2.0.13" />
+    <PackageReference Include="Marain.Tenancy.Client" Version="1.1.15" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.*,)" />

--- a/Solutions/Marain.Claims.Benchmark/Program.cs
+++ b/Solutions/Marain.Claims.Benchmark/Program.cs
@@ -47,7 +47,7 @@
             if (args.Length > 1)
             {
                 string version = args[1];
-                config = config.With(Job.Default.With(new Argument[] { new MsBuildArgument($"/p:Version={version}") }));
+                config = config.AddJob(Job.Default.WithArguments(new Argument[] { new MsBuildArgument($"/p:Version={version}") }));
             }
 
             BenchmarkRunner.Run<SimpleClaimsBenchmarks>(config);

--- a/Solutions/Marain.Claims.Benchmark/packages.lock.json
+++ b/Solutions/Marain.Claims.Benchmark/packages.lock.json
@@ -27,86 +27,86 @@
       },
       "Corvus.Azure.Storage.Tenancy": {
         "type": "Direct",
-        "requested": "[1.1.1, )",
-        "resolved": "1.1.1",
-        "contentHash": "frJ6rmdONMMTMd07YXN6GbnhQs+rw9/WWMvG4ThdV8vxTU3v8kCdBcs6SpeaWEksBbWHI5ReOUF+tjKC8gv2Rw==",
+        "requested": "[2.0.13, )",
+        "resolved": "2.0.13",
+        "contentHash": "naqlx/mpp9OXw0DWQCUMZ93mmyLiLDdk+SSxR9iBMdZXgy/76iO331C5L1Ee24pKizqIq8tmibN35sUr9KN8KA==",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
           "Microsoft.Azure.KeyVault": "3.0.5",
-          "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
-          "Microsoft.Azure.Storage.Blob": "11.2.2",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Microsoft.Azure.Services.AppAuthentication": "1.6.2",
+          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.20"
         }
       },
       "Marain.Tenancy.Client": {
         "type": "Direct",
-        "requested": "[1.1.11, )",
-        "resolved": "1.1.11",
-        "contentHash": "QhL1rpv0dxXnIxHY8sNyPW18hkZsPk9hgW9zVySl/ZFlU75yhulXni2dLJPJxlYeOJmhaxSQqQm9X6D+qXD78w==",
+        "requested": "[1.1.15, )",
+        "resolved": "1.1.15",
+        "contentHash": "7n4jJ5PM1ZlxioQhw8LBPF7xYtFwb4GstPby/Qei8EGxE4HG++uzSDBVG+8TDMmrfR/UA1GuiP6M1VIgaHlgTA==",
         "dependencies": {
-          "CacheCow.Client": "2.8.2",
-          "Corvus.ContentHandling.Json": "2.0.8",
-          "Corvus.Extensions": "1.1.3",
+          "CacheCow.Client": "2.8.3",
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
           "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.16",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "Microsoft.Rest.ClientRuntime": "2.3.23"
         }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "KDfhqlop17pf6zSOzcIydwXNFI8T15Sg7vguGvf9cjPpXCSNSvuWjVpZB+T9KAGQT7mbrB2W0GOYl/1Kgre/7Q==",
+        "resolved": "3.1.20",
+        "contentHash": "qN871hvjHs9pqVW1E8dXzww3hDXmAtSC0Mjvht+2choJN+KKLL/mQpX2Egkp9Wvox005bfmBrFW7svDDTjmuoQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "5XARAKFFAlX6WVk/c2/oAW44Oh0TMYwIFJJqxjkFXjPWsZAFuPTD0yLuaXvnILATpR8guks4V8yTE33HaV7ZOg==",
+        "resolved": "3.1.20",
+        "contentHash": "TpevBA1qF8XuuP5md8As81SHfhtAsVocH/i76F1WjYoOBpA9nwC3dmpN/YDi89efRzU6qk5AYvZ1ldCONtAYSQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "UmyDTRQWG1RaP70rGlymCWlDKK9ZHvypJocinplxeeky3bevDBdI4qnhT0eXQSu/iRlanXvhoyBimh9glXPJjg==",
+        "resolved": "3.1.20",
+        "contentHash": "eS6Q5oRKmBQKlgIjSXmgaF2jwSAuii+3UjTSN4jI2LH1N0utPNgZNtnOVXDU2tZiUOtQuAROBb8PZKgHgIgsYQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "Fbqktw5CRufEEAYvBBWB6QnuFLLk647RvseItBdnKhp3awiXKpjYgLhv3JH6Ndtj8kdwChcfhHjlcZOk+8EXdw==",
+        "resolved": "3.1.20",
+        "contentHash": "117x0om5ZospcNDoUUwHjA/k8sEjGGE+E1R7B7hwo+ZcaWQtk8scnGWYBahKP9yzLpB11HNs3hlv23sSXToogQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "sUwnSp6N8gpeXiAXFOY4SEAyRoeIvRRzPOOQ9+X2w7TkOQSImBWIA5Ol21GV3WOUqD0vukymu0TZ2WaaPiLW9w==",
+        "resolved": "3.1.20",
+        "contentHash": "sNliq6gPP03/lC6dbtBv5EuMX8bnWBOsSaK6qg/TbPtZIV/i8RwxYWYW0Y+koepeLEVae3wtcUBX7sQfaCw3LQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19",
-          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.20"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "cdBicT5kRGBVWilW0QUFYmeqYNgBP3NHwrnsuJj0QqivA74OHcUiS18EFLMRmqwZ746mbnptfSZ4Lh997KsUew==",
+        "resolved": "3.1.20",
+        "contentHash": "JAV97hx4y7qJ5mnjnUOSd+xDnMj2+51c8KVirhuU+rOW1LUnsmjhin86Tep6Q5tOHmNPOmmo6OHEFCdbZj5+zw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "BenchmarkDotNet.Annotations": {
@@ -116,10 +116,10 @@
       },
       "CacheCow.Client": {
         "type": "Transitive",
-        "resolved": "2.8.2",
-        "contentHash": "WiYBnPncYQ1YJRH2C7/tFEWHdK+P4kJEipVTEgGiu2xPJQFc5jZ4hCvWFbLMH08Vbmg51YzR7au+3BbX4CTVyw==",
+        "resolved": "2.8.3",
+        "contentHash": "hatqwAMz+SPi5I0M7iRu5/d/44oimH7UjwWRGCTRCkWC1MszuZx+C1Geys1SG76vaYy+aXSzwMOnuG7R+JCxAg==",
         "dependencies": {
-          "CacheCow.Common": "2.8.2",
+          "CacheCow.Common": "2.8.3",
           "Microsoft.AspNet.WebApi.Client": "5.2.5",
           "Microsoft.Extensions.Caching.Memory": "2.0.1",
           "Newtonsoft.Json": "11.0.1"
@@ -127,8 +127,8 @@
       },
       "CacheCow.Common": {
         "type": "Transitive",
-        "resolved": "2.8.2",
-        "contentHash": "/jA1YHpoqq7xMu8utF5RHPhfHo3RJJbbThhQQykhKrLiHPg1V56Jq7tnOmGUc0KfdbnAhzIOJGT16/TzSXNx9w==",
+        "resolved": "2.8.3",
+        "contentHash": "eJF4/Tn2sVza/7c4RJG8CoBTO/nzdyuesDmL8OE28kN8BML47/6A9/UQk1QEpogG7tLgOfEylrSR8rLRYMPn+Q==",
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.5",
           "Newtonsoft.Json": "11.0.1"
@@ -158,39 +158,39 @@
       },
       "Corvus.ContentHandling": {
         "type": "Transitive",
-        "resolved": "2.0.8",
-        "contentHash": "CwqA/y8jWCGNx8JQaqQqsO3nfa7H8/pVXWf3YLoCE+d9IPUVoV/yXoXml8bGncrw7M9b5oT08mlfxTCaV291mg==",
+        "resolved": "2.0.11",
+        "contentHash": "W4yuYfITGgwPg8KRFlLurwUp9aAsOggedBbtbLPPSmJTJzDK3BMiJnEJh/j0Rc2P37oqv3j8jhf3aOfvn7s5XQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.10.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.16",
+          "Microsoft.CodeAnalysis.CSharp": "3.11.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "System.Runtime.Loader": "4.3.0"
         }
       },
       "Corvus.ContentHandling.Json": {
         "type": "Transitive",
-        "resolved": "2.0.8",
-        "contentHash": "6ZEEpIV5DL9v7ISx7KHEhsemq0Ht+iGnY0lxrOgTODgYThfgQIp88oAR/Wpom+GJ9rURJX+5k7kTWesG6Ow8uA==",
+        "resolved": "2.0.11",
+        "contentHash": "aYnqiQB7nCe+Pq4szhsdBYRpaXcdZX0u77JL57YAKg/Jfty9p5xVB+9cwi+O7z6boD/xOyYjkr44qMvt06i/ng==",
         "dependencies": {
-          "Corvus.ContentHandling": "2.0.8",
-          "Corvus.Extensions.Newtonsoft.Json": "2.0.4",
+          "Corvus.ContentHandling": "2.0.11",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.5",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Corvus.Extensions": {
         "type": "Transitive",
-        "resolved": "1.1.3",
-        "contentHash": "pl8BI4kzov/3Wv1rfS4NdbSPJs02oxI+Zfjn5HhOxV6nG/mdcduhMZoOv5vsQaoCSm2RZMbBuCX1JLpxGeFGbQ==",
+        "resolved": "1.1.4",
+        "contentHash": "WGwNzQDNrlxfH82iRSSXcG92yKhE8xlBMWoSC4dycp0MnH2Mle0TF+Y4keRgDAdDwXg8VC+3paZx64jVG1Jazg==",
         "dependencies": {
           "System.Interactive": "3.2.0"
         }
       },
       "Corvus.Extensions.Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "2.0.4",
-        "contentHash": "rf3yQk7tR3hyb91EVUkyCSwM7ArbUYK74yFBeVddS3pPgQ55D73EBPsv0UQqZO7tJybWio87Zq7bf+Q37Gtm+g==",
+        "resolved": "2.0.5",
+        "contentHash": "d9g6XjfyU5z2gffGNuOD4veWzCEUibioxvYyQkiwOmt+0SL5M0j4C6TNE6015LzEVYtnjLHXM+3op3NUqLtK7g==",
         "dependencies": {
-          "Corvus.Json.Abstractions": "2.0.4",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.16",
+          "Corvus.Json.Abstractions": "2.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -206,17 +206,17 @@
       },
       "Corvus.Json.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.0.4",
-        "contentHash": "ZTC8MBWnvjzJloF+JZt/4Do/n9vDLbEiuixLhs0rbAsVvEC7t3ZkCO1p2IHjgHXODkjyR+8F2x5lmRCKel1AiQ=="
+        "resolved": "2.0.5",
+        "contentHash": "fUuuUwktUoCQNwR2+bvi2AcOPzJkU51o8Js37vCTdXBg4aDLQZaFIuyO9Dg9Sm9NW1hVhK5nBFkBaqbmF5rutg=="
       },
       "Corvus.Tenancy.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Ooq7Y42DWuX6zJkAADrKUjA9m2O8gVnL8OXVJ79e1qmV/dpA2ek25bfO3PBLKbjuCSGWg2JpwXTd//OKWGhX5A==",
+        "resolved": "2.0.13",
+        "contentHash": "uZxeWtTHYmjI580a+MnrwvgW5KLjhXbDA6o0A5Xo1xPRC3cn2xPXXvfO+ClHtJuyh2bzL8gaWjXyj85N4q5oVg==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Iced": {
@@ -306,26 +306,26 @@
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "78AcjpxnhJDov7HJa4kPpZxpI0coZhS0tdA9ZLUSPExKz5KTgfozayBTLAXDuTuq0gLRzFyf85SvIkrtbB8KpA==",
+        "resolved": "1.6.2",
+        "contentHash": "rSQhTv43ionr9rWvE4vxIe/i73XR5hoBYfh7UUgdaVOGW1MZeikR9RmgaJhonTylimCcCuJvrU0zXsSIFOsTGw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
           "System.Diagnostics.Process": "4.3.0"
         }
       },
       "Microsoft.Azure.Storage.Blob": {
         "type": "Transitive",
-        "resolved": "11.2.2",
-        "contentHash": "AV6H+IFCyQvv9jc7KesTdXrGXNi5XKdTABfrX9tychmpe81Y13RlMWN9aJd1gWgNXM2f983vzcaRRFvlxQD23w==",
+        "resolved": "11.2.3",
+        "contentHash": "gM48FyiinUQq+fiUFHf0hGwQaTug4b+zYcYjbZ1KpxC3RkSgOd3twL9Yv9MqpvTkMcexGLwtELYIBhaTQ3zd9A==",
         "dependencies": {
-          "Microsoft.Azure.Storage.Common": "11.2.2",
+          "Microsoft.Azure.Storage.Common": "11.2.3",
           "NETStandard.Library": "2.0.1"
         }
       },
       "Microsoft.Azure.Storage.Common": {
         "type": "Transitive",
-        "resolved": "11.2.2",
-        "contentHash": "t7j1D4I0fm+JkfPdPuWMv8RGdylhj0Pozm4NU6MNJpFxyFaMwl3bwkUCkvyM7xaIXjwghBo5fiHji+wzSTj3ew==",
+        "resolved": "11.2.3",
+        "contentHash": "WqX0ckhXQSUIBEq6wd2xgFz3KPjIONfDdgNg1ClQYxYTvuXQv3g3cnL9DGXCvuxEFZNPk0BJdQeW+uZwGqdDjw==",
         "dependencies": {
           "Microsoft.Azure.KeyVault.Core": "2.0.4",
           "NETStandard.Library": "2.0.1",
@@ -339,8 +339,8 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "Htsk5pJmKjTgUwAP5oyuIODX/b6Zl4RD0tpM62NEncxne/LiQvP50j9g8h+qFtp4lS4AmAYTVPBbXgBuC5zcQA==",
+        "resolved": "3.11.0",
+        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
@@ -353,10 +353,10 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.10.0",
-        "contentHash": "GM83V29l0zsOLReyxpFs32Ujss3wkrVbWFTVjGANXxceycWmi7aLBNL4TQ3r3ZiG4m2b+/LIqwIVkDvZpjOnuw==",
+        "resolved": "3.11.0",
+        "contentHash": "aDRRb7y/sXoJyDqFEQ3Il9jZxyUMHkShzZeCRjQf3SS84n2J0cTEi3TbwVZE9XJvAeMJhGfVVxwOdjYBg6ljmw==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.10.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
       "Microsoft.CSharp": {
@@ -432,80 +432,81 @@
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "F8gKoMRJH/jn81sxujNMAmJA65nirCjPACU25wSKaXGMQ4K/aatb5V70hkzsgffsxNI3EvmTEA2u40NBB4RHYg==",
+        "resolved": "3.1.20",
+        "contentHash": "qqfD7VfSDds340cuVggQQGlSoVuMYAtW6UIczf3UKV8CMfnP7CRc9mjlVl4R5/Jovbd5vkl56E6lg03W/ZWCtA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19",
-          "Microsoft.Extensions.FileProviders.Physical": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.20"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "tiaohUQoNWfUQBWAW4wg9yRYAYcxq0IERI6bR8DojusFIVybdzOJ1bJXLghfO17cGx05SdiUnUk8h0SiQn0hBw=="
+        "resolved": "3.1.20",
+        "contentHash": "a2axLm7TfsB6rELiYDp7qx0S64h1FCFAFGz0WnPWgyshpvLWYM/XKwLHIPqiXuhtEp9kT4qBXRYsXMe6ZrxX0A=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "dl2aT5R9Eq36T3fH0uWPNygApojb4cq4s8+pfFTGJtpy6s8ss4t2vh7Kzi6dr1SC+pgbFkgXLkh8DRl5mqmvLw==",
+        "resolved": "3.1.20",
+        "contentHash": "gR0rfQg7a1DJMlPDRii4fypu/M5tQ/0pf5mGF4jotcTCyT71wCwuONm1IruDJi+rWa4zPBPovRjdGa0Yx4Lxyg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "DZh94lZTqYx2oAuDNckgj28+7gYxjtAOskpSp+2Tu9YKXXgNkFtAKC7QKvpFkGvZK4C3way+R7WI58bIN3aPrw==",
+        "resolved": "3.1.20",
+        "contentHash": "bewykuIeGb6Ro2Vq2/F1rq5jhmCsocDlgEKg2tMThsnfABXjlJbOXyjJl2GztXhtobsDpuOiWH48MM7qSONNtQ==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.19",
-          "Microsoft.Extensions.FileSystemGlobbing": "3.1.19"
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.20",
+          "Microsoft.Extensions.FileSystemGlobbing": "3.1.20"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Htid3HfJu6W5KInQvN31ku2JHU9R0Oy4wlv22M7Paj9x1gjeEx3mhpPVgclnAm/2OCo+b9ZTqwUZD7Mx3lXuBQ=="
+        "resolved": "3.1.20",
+        "contentHash": "2Sz4v3iuv1ZXVxz2/SfdaDVsfbeHirmlFp2zcguyS9IHh2ZxnCzMOLjvmkf+vt/XFRQaIFIDepushHdkif4xsQ=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "Ixi6qAF3sr1FjPntVamRCMcnrCPx6l0G8VxtVshEk4n8lGs0Hj62jmt/xJ4mHrxR5ST0T49ERT2HsJcv6z+wGw=="
+        "resolved": "3.1.20",
+        "contentHash": "pejtJ+FM3tRm9Ssy9VO1PMkxlpkwbO+iQmK/Ot9DqgW3zjeLSQg3bEPI6klU70yoRSDwpiI8E71RdzU+vn/bTQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "by2/frdg182EdpUkFw+2+h+POQTUCVNZRGWgFZKKZhxfuN+hJZFAaGMAuo1ouLexMa1PGTqWAgw/zaZ2WwU71Q==",
+        "resolved": "3.1.20",
+        "contentHash": "K5h3xUrYP8mbGZeGAm/vcWjol2wBh2V1vV+Vz02DCKlZ/99Y8ecKJwdpH+elfdqcEFXy76jk+I1nBsmhPKeCgw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "p4Vz1vR0j5IEx3iA5m73cS3r8InaXL8o5mI9xFCUCpSMJFFPRsx9OSF1BaLbybhOwQ9ZJFeSELLJNGuVWifqEg==",
+        "resolved": "3.1.20",
+        "contentHash": "vmh27AY00NDg6+4P5NbLnhKsrNMBtfcFAoE0Pim7yNAB46ev44vu2O5a3AINUoRl9Kovik72Wgn8qA4IpQu+vg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Configuration.Binder": "3.1.12",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options": "3.1.12"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Configuration.Binder": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options": "3.1.20"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Al3SuZLS4nN7o3TQPfJGHNnQuLEKXz/tBXoPeESMnJxRLCWomo9MAdjEBunexaWK4as+ESVqOD2rLVyBBx3/qA=="
+        "resolved": "3.1.20",
+        "contentHash": "RHHWUHzW8y+dyNBIBmo2EQbpCC6xFQcFMpLhNcpzw3zP0rxJdhmTTdy5eXvhlkNi3vqM4Af5Qqb5xgYwqaoaJQ=="
       },
       "Microsoft.IdentityModel.Clients.ActiveDirectory": {
         "type": "Transitive",
-        "resolved": "5.2.0",
-        "contentHash": "5zCom0plcWSAuPp2B/Fo7XFKdrPUOaE+1dhVW5Ui2Gny7YYv1fDJ1Z8GeZEJuCd3rKN4UBO834wPEhU5gIPQMw==",
+        "resolved": "5.2.9",
+        "contentHash": "WhBAG/9hWiMHIXve4ZgwXP3spRwf7kFFfejf76QA5BvumgnPp8iDkDCiJugzAcpW1YaHB526z1UVxHhVT1E5qw==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0",
           "NETStandard.Library": "1.6.1",
           "System.ComponentModel.TypeConverter": "4.3.0",
           "System.Dynamic.Runtime": "4.3.0",
           "System.Net.Http": "4.3.4",
+          "System.Private.Uri": "4.3.2",
           "System.Runtime.Serialization.Formatters": "4.3.0",
           "System.Runtime.Serialization.Json": "4.3.0",
           "System.Runtime.Serialization.Primitives": "4.3.0",
@@ -522,8 +523,8 @@
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+        "resolved": "1.1.3",
+        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
       },
       "Microsoft.OData.Core": {
         "type": "Transitive",
@@ -1293,6 +1294,15 @@
           "System.Xml.XDocument": "4.3.0",
           "System.Xml.XmlDocument": "4.3.0",
           "System.Xml.XmlSerializer": "4.3.0"
+        }
+      },
+      "System.Private.Uri": {
+        "type": "Transitive",
+        "resolved": "4.3.2",
+        "contentHash": "o1+7RJnu3Ik3PazR7Z7tJhjPdE000Eq2KGLLWhqJJKXj04wrS8lwb1OFtDF9jzXXADhUuZNJZlPc98uwwqmpFA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "System.Reflection": {

--- a/Solutions/Marain.Claims.Host.Functions/packages.lock.json
+++ b/Solutions/Marain.Claims.Host.Functions/packages.lock.json
@@ -24,12 +24,12 @@
       "Microsoft.Extensions.Logging.Console": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "qofNSCPx5RkwsVbt8Y2QizHAx5iYDWxaXHvsXcRHtHZfJ/nnq08zjORcQ6zZUfNqyEWYZAoTfgv9gCWN59BodA==",
+        "resolved": "3.1.20",
+        "contentHash": "v9GpjBR3YBNSnbNj1C4hQmRofUDpya1CgQwZo3IuXbun2JbSmHs1sVxuMyEh8sdU7Bo8gGyA3zdtEwE+16oiVA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Logging": "3.1.19",
-          "Microsoft.Extensions.Logging.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Logging": "3.1.20",
+          "Microsoft.Extensions.Logging.Configuration": "3.1.20"
         }
       },
       "Microsoft.NET.Sdk.Functions": {
@@ -85,48 +85,68 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "CacheCow.Client": {
+        "type": "Transitive",
+        "resolved": "2.8.3",
+        "contentHash": "hatqwAMz+SPi5I0M7iRu5/d/44oimH7UjwWRGCTRCkWC1MszuZx+C1Geys1SG76vaYy+aXSzwMOnuG7R+JCxAg==",
+        "dependencies": {
+          "CacheCow.Common": "2.8.3",
+          "Microsoft.AspNet.WebApi.Client": "5.2.5",
+          "Microsoft.Extensions.Caching.Memory": "2.0.1",
+          "Newtonsoft.Json": "11.0.1"
+        }
+      },
+      "CacheCow.Common": {
+        "type": "Transitive",
+        "resolved": "2.8.3",
+        "contentHash": "eJF4/Tn2sVza/7c4RJG8CoBTO/nzdyuesDmL8OE28kN8BML47/6A9/UQk1QEpogG7tLgOfEylrSR8rLRYMPn+Q==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.5",
+          "Newtonsoft.Json": "11.0.1"
+        }
+      },
       "Corvus.Azure.Cosmos.Tenancy": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "BgD87nmE/DXrE6GVXRKJ8t3DXgeyCuQLJf48xGgfhFmVxkvOOSOPoSxSI4BkcHeZgRTfVUyITOojM4H2XaHs3Q==",
+        "resolved": "2.0.2",
+        "contentHash": "yLJTvsrf5Cg2lQbIpIWMpV56n7b/E2nUz1gWilDtxDvnCAtlo1VUIStHwlFgQ1WnR+RIeyxukOtLCYgs7xFZ7A==",
         "dependencies": {
-          "Corvus.Extensions.CosmosClient": "1.0.5",
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Corvus.Extensions.CosmosClient": "2.0.4",
+          "Corvus.Tenancy.Abstractions": "2.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.13",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.13"
         }
       },
       "Corvus.Azure.Storage.Tenancy": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "frJ6rmdONMMTMd07YXN6GbnhQs+rw9/WWMvG4ThdV8vxTU3v8kCdBcs6SpeaWEksBbWHI5ReOUF+tjKC8gv2Rw==",
+        "resolved": "2.0.13",
+        "contentHash": "naqlx/mpp9OXw0DWQCUMZ93mmyLiLDdk+SSxR9iBMdZXgy/76iO331C5L1Ee24pKizqIq8tmibN35sUr9KN8KA==",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
           "Microsoft.Azure.KeyVault": "3.0.5",
-          "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
-          "Microsoft.Azure.Storage.Blob": "11.2.2",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Microsoft.Azure.Services.AppAuthentication": "1.6.2",
+          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.20"
         }
       },
       "Corvus.ContentHandling": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "O1CJ5Tfv/dFe9y6IOw0EWTnXvDmZe+8cEV1C1RHOv9NwOvxLdp1lHsngxBtcEV41e1jPMqci1ShzFtFB1Wi14Q==",
+        "resolved": "2.0.11",
+        "contentHash": "W4yuYfITGgwPg8KRFlLurwUp9aAsOggedBbtbLPPSmJTJzDK3BMiJnEJh/j0Rc2P37oqv3j8jhf3aOfvn7s5XQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.8.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
+          "Microsoft.CodeAnalysis.CSharp": "3.11.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "System.Runtime.Loader": "4.3.0"
         }
       },
       "Corvus.ContentHandling.Json": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "Nxn2qhw3DqJeX63+TY+PNePqFIwyupocUubsfz70d2Qgk6k66Kx2KBxd5pXotmhQKY2IAw2uxHhWCnGAP/wOVw==",
+        "resolved": "2.0.11",
+        "contentHash": "aYnqiQB7nCe+Pq4szhsdBYRpaXcdZX0u77JL57YAKg/Jfty9p5xVB+9cwi+O7z6boD/xOyYjkr44qMvt06i/ng==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.ContentHandling": "2.0.11",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.5",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -140,13 +160,13 @@
       },
       "Corvus.Extensions.CosmosClient": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "uhwd53ei0YTinBU1xX9Ci9xMGzbecfONhia+xdwDK5o7+oCNnA9HRyoSmQfGZ3+VJaWWqYEFVYDSqfARii/u6Q==",
+        "resolved": "2.0.4",
+        "contentHash": "QhX2y2JhofFQMW+6rxGno8VUD8Zd1fd1o0+pPw3/tsTbRGrTVggx8xhJrzRRxuXKTWWobBGMEP2zW8z+1rwLWg==",
         "dependencies": {
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
-          "Corvus.Retry": "1.0.1",
-          "Microsoft.Azure.Cosmos": "3.16.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
+          "Corvus.Retry": "1.0.2",
+          "Microsoft.Azure.Cosmos": "3.17.0",
           "Microsoft.Azure.KeyVault": "3.0.5",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.Bcl.HashCode": "1.1.1"
@@ -154,11 +174,11 @@
       },
       "Corvus.Extensions.Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "cgnu26gsI09OO7v9KNkgNpKRiWCD27GFE8R2STjyRgVuIGnDaKP5tQlUh3hQS1Rmw0F0fYGSbRGMdAUCwnVd2A==",
+        "resolved": "2.0.6",
+        "contentHash": "6yXJ7xbflSB3c0G7hdNExwlhbEChMRcSn6fX4k8ghhWyADrDSY6jJp9Ce6guxo1c4gVjZwgCVIDhA3JgO8KyHA==",
         "dependencies": {
-          "Corvus.Json.Abstractions": "1.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
+          "Corvus.Json.Abstractions": "2.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -174,125 +194,126 @@
       },
       "Corvus.Json.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "tkj8QDNAKoemvMGLnIHLiuQiaI8DfKpT8T1snqd9/UYzZeIonjjM/MtaJOq5PP+AB3L2h8ZaFA/sgryJMIxsGw=="
+        "resolved": "2.0.6",
+        "contentHash": "ixx72ttlP/Ck+UMWyfiRWVBFKU5XjJySMG33ZWofJp9yy65VF3uOJyGPujr3OedUMo6Uq9umftmHRqhOmUyQ8g=="
       },
       "Corvus.Monitoring.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "tnbCflVOaiN6koeu0zwqwmj0q0W7Nr2f4M7YnQcav0n4IjxZLEVEJx3tZ241naoSl4XPPeHo9pT7zukdOGoDVg==",
+        "resolved": "1.3.2",
+        "contentHash": "Qt3kxNn2r0bSJHbraRc9WxMYwvJnSZfv+tb4tBUYTJQ+eYvGe4cg8HIsRRQcxsPnTJP9dLmfcK7xQ6y0c5ARrg==",
         "dependencies": {
-          "Corvus.Monitoring.Instrumentation.Abstractions": "1.3.1",
+          "Corvus.Monitoring.Instrumentation.Abstractions": "1.3.2",
           "Microsoft.ApplicationInsights": "2.9.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Corvus.Monitoring.Instrumentation.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "ZGQtoehovlD/VhiPIew93LBU1wi3/gqYKFCxC9PGZU7I+/x1d2FD8RM6a6Zk6satmQSttif8eyAXZJDvMOuF+A==",
+        "resolved": "1.3.2",
+        "contentHash": "IEnBaceaj7kJYF96xBusLOQs3GBYaN4TywNzdsNf3Ol7g4NxpCilVSY+mBw1aLbDGm3WapZ2KfaHW7Wo3iWI/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Corvus.Retry": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "aEshkQnOjIJ/F2N0iQHx97A23IeTqqsyIFWBT08gbApr8MUrn8lxpmk5ASpzxCxLUFz+cQiknGbc4etpsorHCA=="
+        "resolved": "1.0.2",
+        "contentHash": "Jzmv1VpjJnIaz+b0uadkl3yoNh+qnmzHvOcHUXc5oAo1fVqclzxLJAqhOPnm5BVURA5nlqgB3mtmI1YQQhwh9A=="
       },
       "Corvus.Tenancy.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Ooq7Y42DWuX6zJkAADrKUjA9m2O8gVnL8OXVJ79e1qmV/dpA2ek25bfO3PBLKbjuCSGWg2JpwXTd//OKWGhX5A==",
+        "resolved": "2.0.13",
+        "contentHash": "uZxeWtTHYmjI580a+MnrwvgW5KLjhXbDA6o0A5Xo1xPRC3cn2xPXXvfO+ClHtJuyh2bzL8gaWjXyj85N4q5oVg==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Corvus.Tenancy.Storage.Azure.Blob": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "y3pzhj27pjgAYfUhWkI8jhoThkvl9Pi/SFSizYAosQqVNSuE/NSvka4E9kepny5uP9F0LjPBUbfMaWlNyeCwtA==",
+        "resolved": "2.0.13",
+        "contentHash": "dOiRROsPh90WZsejYWSQlIspeC9sGbpzuVFrc+GbfbFoUNvxSpxsFdD2ZNsdOWWE+gBYOIRHMMek1hL2welMTw==",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
-          "Corvus.Tenancy.Abstractions": "1.1.1"
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
+          "Corvus.Tenancy.Abstractions": "2.0.13"
         }
       },
       "Marain.Services.Tenancy": {
         "type": "Transitive",
-        "resolved": "2.2.2",
-        "contentHash": "6PytV+UCYuhKWGHYeBrOdbQWz0vhZbsFEq0bepCjAi3ULICYhrhPHKYbGsk7Dw/0jgJrLjVp4kGc2LL2uIxymQ==",
+        "resolved": "2.3.3",
+        "contentHash": "Gqo6MqvgdtwCOMeo3gQKk7t1ngDNiBhuF1g0180NUiHQMsxLl8pN0G9p42lKPDL59jbQX573yUgrtE5wU+vLfQ==",
         "dependencies": {
-          "Marain.TenantManagement.Abstractions": "2.2.2",
-          "Menes.Abstractions": "1.2.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12"
+          "Marain.TenantManagement.Abstractions": "2.3.3",
+          "Menes.Abstractions": "2.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.13"
         }
       },
       "Marain.Tenancy.Client": {
         "type": "Transitive",
-        "resolved": "1.1.2",
-        "contentHash": "770vE+oTJ2/U9ouAVhv92e+YqKuL/q4ZotSOoKL/qZ9SByOcmtH5w7k+biBiXLTAsq2hupUed8m3IY+CqnogNQ==",
+        "resolved": "1.1.15",
+        "contentHash": "7n4jJ5PM1ZlxioQhw8LBPF7xYtFwb4GstPby/Qei8EGxE4HG++uzSDBVG+8TDMmrfR/UA1GuiP6M1VIgaHlgTA==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
-          "Microsoft.Rest.ClientRuntime": "2.3.22"
+          "CacheCow.Client": "2.8.3",
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Rest.ClientRuntime": "2.3.23"
         }
       },
       "Marain.Tenancy.ClientTenantProvider": {
         "type": "Transitive",
-        "resolved": "1.1.2",
-        "contentHash": "aWtNXUf66vBFdjc1+eGWLp4uMpBbYSqH2/Wp7pNMvGidbXGFDN2AwsThLXyhuhsYRnRH3+yayO/GN+nVba1pLg==",
+        "resolved": "1.1.15",
+        "contentHash": "wlvnIThDewTcjCjeOUR1Ns/Y12AIAMjkG9otVBpIebvSIsCkZXkhEhEGyLtsQkHCbckx8Y2iSyfZo42tHNjoGA==",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Marain.Tenancy.Client": "1.1.2",
+          "Corvus.Tenancy.Abstractions": "2.0.12",
+          "Marain.Tenancy.Client": "1.1.15",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0"
         }
       },
       "Marain.TenantManagement.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.2",
-        "contentHash": "0cEk4QkHeZ7KOy7jLxC45ajbtQb3kGWRI0RUQeoNNPpXJ7sc1QLCFM6yuxOfeJr4uGoGT6/I5TW1r7cpNpOrKQ==",
+        "resolved": "2.3.3",
+        "contentHash": "CBBYF1RSNITOssgphcvUimlkFbn1/7yUXY+iohgapzG3DLAcsfqft6/IPseX+3s4nlL/Mcfsx3hwKbjWMRRiqQ==",
         "dependencies": {
-          "Corvus.Azure.Cosmos.Tenancy": "1.1.1",
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Microsoft.Extensions.Logging": "3.1.12"
+          "Corvus.Azure.Cosmos.Tenancy": "2.0.2",
+          "Corvus.Azure.Storage.Tenancy": "2.0.2",
+          "Corvus.Tenancy.Abstractions": "2.0.2",
+          "Microsoft.Extensions.Logging": "3.1.13"
         }
       },
       "Menes.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "H6Q4P6LVCJzXepyrvFYallQy8refCBOdlp1ymXJxBVkYSX9iQJFYvc0PSUVY6QPLKS9svE59kecVMFpgGgDUcw==",
+        "resolved": "2.0.1",
+        "contentHash": "uNJTJhw3gHx2NYuQUt8YV/UGtPhqzvN+Xh1QWLia0ZmUByNJ19GcDtCE4pPfabnPp2eL23NhJUN7UvhWWeUNog==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
+          "Corvus.ContentHandling": "2.0.4",
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
           "Corvus.Monitoring.Instrumentation.Abstractions": "1.2.0",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Logging": "3.1.12",
+          "Microsoft.Extensions.Logging": "3.1.13",
           "Microsoft.OpenApi.Readers": "1.2.3",
           "System.Interactive": "4.1.1",
-          "System.Text.Encodings.Web": "4.7.1",
+          "System.Text.Encodings.Web": "4.7.2",
           "Tavis.UriTemplates": "1.1.1"
         }
       },
       "Menes.Hosting": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "n82LVUCzHph96w8X7LjQP88Pj2QNFxJ3EmSYLlL7jIgdFdKhHYQqc1NXiLGcLQwLTtfvIxbvpQAxhAlOzPBLJw==",
+        "resolved": "2.0.1",
+        "contentHash": "wRXHxNfI9Bwl7Qnpz74HfZeDNFSjMHBNjXmpn7yuErxtP8ujjGxqZEOdiPPQ457N4prmShbOVPaYtQVdbaXnNw==",
         "dependencies": {
-          "Menes.Abstractions": "1.2.1"
+          "Menes.Abstractions": "2.0.1"
         }
       },
       "Menes.Hosting.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "4a3OAXeVUi+mhB2JeIaRPlqut5QE9CQxol9RiUM7C3SjEMhQDVOZJxJqILIEj/Q59khYzRmLScNira5ECymdmg==",
+        "resolved": "2.0.1",
+        "contentHash": "Zpzf8AHD7BQ7gOBe52Dw+tcZc+eh/7HLrCe9YHkw5PqjaF6SpvMfSpKowSTJLF1p5CVqQIxuNIyITl2/rYTDJQ==",
         "dependencies": {
-          "Menes.Hosting": "1.2.1",
+          "Menes.Hosting": "2.0.1",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -307,8 +328,8 @@
       },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
-        "resolved": "5.2.4",
-        "contentHash": "OdBVC2bQWkf9qDd7Mt07ev4SwIdu6VmLBMTWC0D5cOP/HWSXyv/77otwtXVrAo42duNjvXOjzjP5oOI9m1+DTQ==",
+        "resolved": "5.2.5",
+        "contentHash": "ie1BsWwmdD9n3DDhVqEmV0A5UohtBsPFHNL2YPT3KUynBZN8iNaLsRtQwMFg/TVcjiZYAh1sCdMYW7I9DQTLww==",
         "dependencies": {
           "Newtonsoft.Json": "10.0.1",
           "Newtonsoft.Json.Bson": "1.0.1"
@@ -510,8 +531,8 @@
       },
       "Microsoft.Azure.Cosmos": {
         "type": "Transitive",
-        "resolved": "3.16.0",
-        "contentHash": "8CVDpwJcGlD1ehuKde5Uju0gjeIcDQIq5xmhE8VnrWH1DjzZ3nJ2uGVMqCj7G8XYkxTR9m42E7wREOEbMYF++g==",
+        "resolved": "3.17.0",
+        "contentHash": "SDUIpfOWKiE+RMe9RcaxatmSlzC+MqC0hRInEWqU9n0ntG1M2Hv/0IT5He6LQMe2io59gxUvMHuIZe9Dih8hjw==",
         "dependencies": {
           "Azure.Core": "1.3.0",
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
@@ -605,10 +626,10 @@
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "78AcjpxnhJDov7HJa4kPpZxpI0coZhS0tdA9ZLUSPExKz5KTgfozayBTLAXDuTuq0gLRzFyf85SvIkrtbB8KpA==",
+        "resolved": "1.6.2",
+        "contentHash": "rSQhTv43ionr9rWvE4vxIe/i73XR5hoBYfh7UUgdaVOGW1MZeikR9RmgaJhonTylimCcCuJvrU0zXsSIFOsTGw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
           "System.Diagnostics.Process": "4.3.0"
         }
       },
@@ -715,29 +736,29 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "ojG5pGAhTPmjxRGTNvuszO3H8XPZqksDwr9xLd4Ae/JBjZZdl6GuoLk7uLMf+o7yl5wO0TAqoWcEKkEWqrZE5g=="
+        "resolved": "3.3.2",
+        "contentHash": "7xt6zTlIEizUgEsYAIgm37EbdkiMmr6fP6J9pDoKEpiGM4pi32BCPGr/IczmSJI9Zzp0a6HOzpr9OvpMP+2veA=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "8YTZ7GpsbTdC08DITx7/kwV0k4SC6cbBAFqc13cOm5vKJZcEIAh51tNSyGSkWisMgYCr96B2wb5Zri1bsla3+g==",
+        "resolved": "3.11.0",
+        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
           "System.Memory": "4.5.4",
           "System.Reflection.Metadata": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.7.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
           "System.Text.Encoding.CodePages": "4.5.1",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "hKqFCUSk9TIMBDjiYMF8/ZfK9p9mzpU+slM73CaCHu4ctfkoqJGHLQhyT8wvrYsIg+ufrUWBF8hcJYmyr5rc5Q==",
+        "resolved": "3.11.0",
+        "contentHash": "aDRRb7y/sXoJyDqFEQ3Il9jZxyUMHkShzZeCRjQf3SS84n2J0cTEi3TbwVZE9XJvAeMJhGfVVxwOdjYBg6ljmw==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.8.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
       "Microsoft.CSharp": {
@@ -760,28 +781,46 @@
           "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "NobDNbehAbMYUApMXLd9XSt9UznGCgPW9PW4Ybe6S5jKqkd5RcTnaKm0FODcgyx+7B1hIGx7dZwa1bVdiSbHAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "2.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "GVtJD0uhoLOkXBfYZAIRDexEr2qg0QHbUo3CIjmtoGpFWHuGHTvjGqRlybMKIYTpt0BxKpXMn4fqhS4ff10llA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "2.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0",
+          "Microsoft.Extensions.Options": "2.0.1"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "KDfhqlop17pf6zSOzcIydwXNFI8T15Sg7vguGvf9cjPpXCSNSvuWjVpZB+T9KAGQT7mbrB2W0GOYl/1Kgre/7Q==",
+        "resolved": "3.1.20",
+        "contentHash": "qN871hvjHs9pqVW1E8dXzww3hDXmAtSC0Mjvht+2choJN+KKLL/mQpX2Egkp9Wvox005bfmBrFW7svDDTjmuoQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "5XARAKFFAlX6WVk/c2/oAW44Oh0TMYwIFJJqxjkFXjPWsZAFuPTD0yLuaXvnILATpR8guks4V8yTE33HaV7ZOg==",
+        "resolved": "3.1.20",
+        "contentHash": "TpevBA1qF8XuuP5md8As81SHfhtAsVocH/i76F1WjYoOBpA9nwC3dmpN/YDi89efRzU6qk5AYvZ1ldCONtAYSQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "UmyDTRQWG1RaP70rGlymCWlDKK9ZHvypJocinplxeeky3bevDBdI4qnhT0eXQSu/iRlanXvhoyBimh9glXPJjg==",
+        "resolved": "3.1.20",
+        "contentHash": "eS6Q5oRKmBQKlgIjSXmgaF2jwSAuii+3UjTSN4jI2LH1N0utPNgZNtnOVXDU2tZiUOtQuAROBb8PZKgHgIgsYQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
@@ -813,16 +852,16 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "cdBicT5kRGBVWilW0QUFYmeqYNgBP3NHwrnsuJj0QqivA74OHcUiS18EFLMRmqwZ746mbnptfSZ4Lh997KsUew==",
+        "resolved": "3.1.20",
+        "contentHash": "JAV97hx4y7qJ5mnjnUOSd+xDnMj2+51c8KVirhuU+rOW1LUnsmjhin86Tep6Q5tOHmNPOmmo6OHEFCdbZj5+zw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "tiaohUQoNWfUQBWAW4wg9yRYAYcxq0IERI6bR8DojusFIVybdzOJ1bJXLghfO17cGx05SdiUnUk8h0SiQn0hBw=="
+        "resolved": "3.1.20",
+        "contentHash": "a2axLm7TfsB6rELiYDp7qx0S64h1FCFAFGz0WnPWgyshpvLWYM/XKwLHIPqiXuhtEp9kT4qBXRYsXMe6ZrxX0A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -855,8 +894,8 @@
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Htid3HfJu6W5KInQvN31ku2JHU9R0Oy4wlv22M7Paj9x1gjeEx3mhpPVgclnAm/2OCo+b9ZTqwUZD7Mx3lXuBQ=="
+        "resolved": "3.1.20",
+        "contentHash": "2Sz4v3iuv1ZXVxz2/SfdaDVsfbeHirmlFp2zcguyS9IHh2ZxnCzMOLjvmkf+vt/XFRQaIFIDepushHdkif4xsQ=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Transitive",
@@ -883,27 +922,27 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Wv/p90AEtp69cPuQQKAFQCS2tIefqaT6elTx3AwLgltkDXvzGVPbXI7NcfOWh3TNdDcfwV7U6YFC0WrNVA88WA==",
+        "resolved": "3.1.20",
+        "contentHash": "/CuUfjdPd0X6upL/783pzJTSGLm1XTHlonKcRYi5oGVHuN0ESHRjWwmBvrAPf8TXXL901K9oyxJ9mtG9pTmF8Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection": "3.1.19",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Options": "3.1.19"
+          "Microsoft.Extensions.Configuration.Binder": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection": "3.1.20",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options": "3.1.20"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "ZJxpOfelPknOpD+/P+vcvXXAo7JVwBu2n/NkTuQzwneVzqJFzXB4lJu/jr4sbMIrTNvJi/XixPHrKcaztVkXSQ=="
+        "resolved": "3.1.20",
+        "contentHash": "pejtJ+FM3tRm9Ssy9VO1PMkxlpkwbO+iQmK/Ot9DqgW3zjeLSQg3bEPI6klU70yoRSDwpiI8E71RdzU+vn/bTQ=="
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "7OCff9UJ9j20HM+6DkyshiSTQHJP4l0+CmNattTYqNO1kRxwupSnwfIAwWDEYj4cX1Wpp3sfTGbu92hjF625nw==",
+        "resolved": "3.1.20",
+        "contentHash": "+k33hBevAq2hZi4tHnsQwtZDXAkD79MTntOvX5ID6kMgU6piqthMLMoK5uMJAh7vec8ORMhwSIkhjYaQ7wx4gw==",
         "dependencies": {
-          "Microsoft.Extensions.Logging": "3.1.19",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.19"
+          "Microsoft.Extensions.Logging": "3.1.20",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.20"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -913,39 +952,40 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "awGsLKbgxb/3jxmKQQpD2aPAsWW//d8MTQfFB2XgU2xnjLCx+GN5EPdLe6GfB9ulMq/2AiqZ3IXciHBzSGQ1Uw==",
+        "resolved": "3.1.20",
+        "contentHash": "K5h3xUrYP8mbGZeGAm/vcWjol2wBh2V1vV+Vz02DCKlZ/99Y8ecKJwdpH+elfdqcEFXy76jk+I1nBsmhPKeCgw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "wcPJBm5oKhGLYoTzN8CQIDrLvDCAHxI5JZXQbHNcsKmuc5JYO+I/iTGqnJ7UPw40HI4YhvsnwooeMsJZdHQGWg==",
+        "resolved": "3.1.20",
+        "contentHash": "vmh27AY00NDg6+4P5NbLnhKsrNMBtfcFAoE0Pim7yNAB46ev44vu2O5a3AINUoRl9Kovik72Wgn8qA4IpQu+vg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Configuration.Binder": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Options": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Configuration.Binder": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options": "3.1.20"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Al3SuZLS4nN7o3TQPfJGHNnQuLEKXz/tBXoPeESMnJxRLCWomo9MAdjEBunexaWK4as+ESVqOD2rLVyBBx3/qA=="
+        "resolved": "3.1.20",
+        "contentHash": "RHHWUHzW8y+dyNBIBmo2EQbpCC6xFQcFMpLhNcpzw3zP0rxJdhmTTdy5eXvhlkNi3vqM4Af5Qqb5xgYwqaoaJQ=="
       },
       "Microsoft.IdentityModel.Clients.ActiveDirectory": {
         "type": "Transitive",
-        "resolved": "5.2.0",
-        "contentHash": "5zCom0plcWSAuPp2B/Fo7XFKdrPUOaE+1dhVW5Ui2Gny7YYv1fDJ1Z8GeZEJuCd3rKN4UBO834wPEhU5gIPQMw==",
+        "resolved": "5.2.9",
+        "contentHash": "WhBAG/9hWiMHIXve4ZgwXP3spRwf7kFFfejf76QA5BvumgnPp8iDkDCiJugzAcpW1YaHB526z1UVxHhVT1E5qw==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0",
           "NETStandard.Library": "1.6.1",
           "System.ComponentModel.TypeConverter": "4.3.0",
           "System.Dynamic.Runtime": "4.3.0",
           "System.Net.Http": "4.3.4",
+          "System.Private.Uri": "4.3.2",
           "System.Runtime.Serialization.Formatters": "4.3.0",
           "System.Runtime.Serialization.Json": "4.3.0",
           "System.Runtime.Serialization.Primitives": "4.3.0",
@@ -995,8 +1035,8 @@
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+        "resolved": "1.1.3",
+        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
       },
       "Microsoft.OData.Core": {
         "type": "Transitive",
@@ -1085,53 +1125,10 @@
       },
       "NETStandard.Library": {
         "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+        "resolved": "2.0.1",
+        "contentHash": "oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.Win32.Primitives": "4.3.0",
-          "System.AppContext": "4.3.0",
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Console": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Globalization.Calendars": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.Compression": "4.3.0",
-          "System.IO.Compression.ZipFile": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Net.Http": "4.3.0",
-          "System.Net.Primitives": "4.3.0",
-          "System.Net.Sockets": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
-          "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Timer": "4.3.0",
-          "System.Xml.ReaderWriter": "4.3.0",
-          "System.Xml.XDocument": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
       "Newtonsoft.Json": {
@@ -1167,15 +1164,6 @@
         "type": "Transitive",
         "resolved": "4.3.0",
         "contentHash": "c/qWt2LieNZIj1jGnVNsE2Kl23Ya2aSTBuXMD6V7k9KWr6l16Tqdwq+hJScEpWER9753NWC8h96PaVNY5Ld7Jw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
-        }
-      },
-      "runtime.native.System.IO.Compression": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0"
@@ -1274,10 +1262,10 @@
       },
       "System.AppContext": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+        "resolved": "4.1.0",
+        "contentHash": "3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
         "dependencies": {
-          "System.Runtime": "4.3.0"
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Buffers": {
@@ -1396,18 +1384,6 @@
         "dependencies": {
           "System.Security.Cryptography.ProtectedData": "4.5.0",
           "System.Security.Permissions": "4.5.0"
-        }
-      },
-      "System.Console": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Text.Encoding": "4.3.0"
         }
       },
       "System.Diagnostics.Debug": {
@@ -1569,44 +1545,6 @@
           "System.Runtime": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
-        }
-      },
-      "System.IO.Compression": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "System.Buffers": "4.3.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "runtime.native.System": "4.3.0",
-          "runtime.native.System.IO.Compression": "4.3.0"
-        }
-      },
-      "System.IO.Compression.ZipFile": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
-        "dependencies": {
-          "System.Buffers": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.Compression": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.Encoding": "4.3.0"
         }
       },
       "System.IO.FileSystem": {
@@ -1840,15 +1778,15 @@
       },
       "System.Net.Sockets": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
+        "resolved": "4.1.0",
+        "contentHash": "xAz0N3dAV/aR/9g8r0Y5oEqU1JRsz29F5EGb/WVHmX3jVSLqi2/92M5hTad2aNWovruXrJpJtgZ9fccPMG9uSw==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Net.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.IO": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Runtime": "4.1.0",
+          "System.Threading.Tasks": "4.0.11"
         }
       },
       "System.Net.WebHeaderCollection": {
@@ -1909,6 +1847,15 @@
           "System.Xml.XDocument": "4.3.0",
           "System.Xml.XmlDocument": "4.3.0",
           "System.Xml.XmlSerializer": "4.3.0"
+        }
+      },
+      "System.Private.Uri": {
+        "type": "Transitive",
+        "resolved": "4.3.2",
+        "contentHash": "o1+7RJnu3Ik3PazR7Z7tJhjPdE000Eq2KGLLWhqJJKXj04wrS8lwb1OFtDF9jzXXADhUuZNJZlPc98uwwqmpFA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "System.Reflection": {
@@ -2017,8 +1964,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -2055,16 +2002,16 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+        "resolved": "4.0.0",
+        "contentHash": "hWPhJxc453RCa8Z29O91EmfGeZIHX1ZH2A8L6lYQVSaKzku2DfArSfMEb1/MYYzPQRJZeu0c9dmYeJKxW5Fgng==",
         "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Threading": "4.3.0",
-          "runtime.native.System": "4.3.0"
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11",
+          "runtime.native.System": "4.0.0"
         }
       },
       "System.Runtime.Loader": {
@@ -2349,8 +2296,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "3qreYFQcLnyFk1LuaNWyyWE+sfkfe5eSTaIIssYrLNUIDbgyZNQBYQSzSDo4AprpjVeVX2T4KHKii9fiSZVUow=="
+        "resolved": "4.7.2",
+        "contentHash": "iTUgB/WtrZ1sWZs84F2hwyQhiRH6QNjQv2DkwrH+WP6RoFga2Q1m3f9/Q7FG8cck8AdHitQkmkXSY8qylcDmuA=="
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -2415,16 +2362,6 @@
         "dependencies": {
           "System.Runtime": "4.3.0",
           "System.Runtime.Handles": "4.3.0"
-        }
-      },
-      "System.Threading.Timer": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
         }
       },
       "System.ValueTuple": {
@@ -2534,8 +2471,8 @@
       "marain.claims.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Menes.Abstractions": "1.2.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
+          "Menes.Abstractions": "2.0.1",
           "Microsoft.Extensions.FileSystemGlobbing": "3.1.0",
           "Newtonsoft.Json": "12.0.3"
         }
@@ -2544,13 +2481,13 @@
         "type": "Project",
         "dependencies": {
           "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.7",
-          "Corvus.Monitoring.ApplicationInsights": "1.3.1",
-          "Corvus.Tenancy.Storage.Azure.Blob": "1.1.1",
+          "Corvus.Monitoring.ApplicationInsights": "1.3.2",
+          "Corvus.Tenancy.Storage.Azure.Blob": "2.0.13",
           "Marain.Claims.OpenApi": "1.0.0",
           "Marain.Claims.OpenApi.AspNetCore": "1.0.0",
           "Marain.Claims.OpenApi.Service": "1.0.0",
           "Marain.Claims.Tenancy.AzureBlob": "1.0.0",
-          "Marain.Tenancy.ClientTenantProvider": "1.1.2"
+          "Marain.Tenancy.ClientTenantProvider": "1.1.15"
         }
       },
       "marain.claims.openapi": {
@@ -2562,7 +2499,7 @@
       "marain.claims.openapi.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
+          "Corvus.ContentHandling.Json": "2.0.11",
           "Marain.Claims.OpenApi": "1.0.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "System.IdentityModel.Tokens.Jwt": "5.5.0"
@@ -2571,9 +2508,9 @@
       "marain.claims.openapi.service": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
           "Marain.Claims.Abstractions": "1.0.0",
-          "Marain.Services.Tenancy": "2.2.2",
+          "Marain.Services.Tenancy": "2.3.3",
           "Microsoft.ApplicationInsights": "2.18.0",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.0"
@@ -2583,7 +2520,7 @@
         "type": "Project",
         "dependencies": {
           "Corvus.Extensions": "1.1.4",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.6",
           "Marain.Claims.Abstractions": "1.0.0",
           "Microsoft.Azure.Storage.Blob": "11.2.3"
         }
@@ -2591,10 +2528,10 @@
       "marain.claims.tenancy.azureblob": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
           "Marain.Claims.OpenApi": "1.0.0",
           "Marain.Claims.Storage.AzureBlob": "1.0.0",
-          "Menes.Hosting.AspNetCore": "1.2.1",
+          "Menes.Hosting.AspNetCore": "2.0.1",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.0"
         }

--- a/Solutions/Marain.Claims.Hosting.AspNetCore/Marain.Claims.Hosting.AspNetCore.csproj
+++ b/Solutions/Marain.Claims.Hosting.AspNetCore/Marain.Claims.Hosting.AspNetCore.csproj
@@ -12,14 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Monitoring.ApplicationInsights" Version="1.3.1" />
+    <PackageReference Include="Corvus.Monitoring.ApplicationInsights" Version="1.3.2" />
     <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.7" />
-    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="1.1.1" />
+    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="2.0.13" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="1.1.2" />
+    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="1.1.15" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Claims.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/ClaimsServiceCollectionExtensions.cs
+++ b/Solutions/Marain.Claims.Hosting.AspNetCore/Microsoft/Extensions/DependencyInjection/ClaimsServiceCollectionExtensions.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Extensions.DependencyInjection
     using Menes.AccessControlPolicies;
     using Microsoft.Extensions.Configuration;
 
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Serialization;
+
     /// <summary>
     /// Extension methods for configuring DI for the Operations Open API services.
     /// </summary>
@@ -44,7 +48,6 @@ namespace Microsoft.Extensions.DependencyInjection
             // Work around the fact that the tenancy client currently tries to fetch the root tenant on startup.
             services.AddMarainServiceConfiguration();
 
-            services.AddRootTenant();
             services.AddMarainServicesTenancy();
             services.AddSingleton(sp => sp.GetRequiredService<IConfiguration>().GetSection("TenancyClient").Get<TenancyClientOptions>());
             services.AddTenantProviderServiceClient();
@@ -63,7 +66,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddTenantedBlobContainerClaimsStore();
 
-            services.AddJsonSerializerSettings();
+            services.AddJsonNetSerializerSettingsProvider();
+            services.AddJsonNetPropertyBag();
+            services.AddJsonNetCultureInfoConverter();
+            services.AddJsonNetDateTimeOffsetToIso8601AndUnixTimeConverter();
+            services.AddSingleton<JsonConverter>(new StringEnumConverter(new CamelCaseNamingStrategy()));
 
             services.AddSingleton<ClaimPermissionsService>();
             services.AddSingleton<IOpenApiService, ClaimPermissionsService>(s => s.GetRequiredService<ClaimPermissionsService>());

--- a/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain.Claims.OpenApi.AspNetCore.csproj
+++ b/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain.Claims.OpenApi.AspNetCore.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="1.1.0" />
+    <PackageReference Include="Corvus.ContentHandling.Json" Version="2.0.11" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Claims.OpenApi.Service/Marain.Claims.OpenApi.Service.csproj
+++ b/Solutions/Marain.Claims.OpenApi.Service/Marain.Claims.OpenApi.Service.csproj
@@ -23,12 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.1.1" />
+    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="2.0.13" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Marain.Services.Tenancy" Version="2.2.2" />
+    <PackageReference Include="Marain.Services.Tenancy" Version="2.3.3" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[3.1.*,)" />

--- a/Solutions/Marain.Claims.OpenApi.Specs/Bindings/FunctionsContainerBindings.cs
+++ b/Solutions/Marain.Claims.OpenApi.Specs/Bindings/FunctionsContainerBindings.cs
@@ -17,6 +17,10 @@ namespace Marain.Workflows.Api.Specs.Bindings
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
 
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Serialization;
+
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -44,7 +48,11 @@ namespace Marain.Workflows.Api.Specs.Bindings
                     IConfiguration root = configurationBuilder.Build();
 
                     services.AddSingleton(root);
-                    services.AddJsonSerializerSettings();
+                    services.AddJsonNetSerializerSettingsProvider();
+                    services.AddJsonNetPropertyBag();
+                    services.AddJsonNetCultureInfoConverter();
+                    services.AddJsonNetDateTimeOffsetToIso8601AndUnixTimeConverter();
+                    services.AddSingleton<JsonConverter>(new StringEnumConverter(new CamelCaseNamingStrategy()));
 
                     services.AddLogging();
 
@@ -56,7 +64,6 @@ namespace Marain.Workflows.Api.Specs.Bindings
                             AzureServicesAuthConnectionString = azureServicesAuthConnectionString,
                         });
 
-                    services.AddRootTenant();
                     services.AddSingleton(sp => sp.GetRequiredService<IConfiguration>().GetSection("TenancyClient").Get<TenancyClientOptions>());
 
                     TenancyClientOptions tenancyClientConfiguration = root.GetSection("TenancyClient").Get<TenancyClientOptions>();

--- a/Solutions/Marain.Claims.OpenApi.Specs/Marain.Claims.OpenApi.Specs.csproj
+++ b/Solutions/Marain.Claims.OpenApi.Specs/Marain.Claims.OpenApi.Specs.csproj
@@ -40,15 +40,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow.NUnit" Version="1.4.5" />
+    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow.NUnit" Version="1.4.6" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Marain.Services.Tenancy" Version="2.2.2" />
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.0.1" />
-    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="1.1.2" />
-    <PackageReference Include="Menes.Testing.AspNetCoreSelfHosting" Version="1.2.1" />
+    <PackageReference Include="Marain.Services.Tenancy" Version="2.3.3" />
+    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.3.3" />
+    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="1.1.15" />
+    <PackageReference Include="Menes.Testing.AspNetCoreSelfHosting" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
   </ItemGroup>
 

--- a/Solutions/Marain.Claims.OpenApi.Specs/packages.lock.json
+++ b/Solutions/Marain.Claims.OpenApi.Specs/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETCoreApp,Version=v3.1": {
       "Corvus.Testing.AzureFunctions.SpecFlow.NUnit": {
         "type": "Direct",
-        "requested": "[1.4.5, )",
-        "resolved": "1.4.5",
-        "contentHash": "eE1Br/PmesozRzMSpGlapFhUUYW7qT7i+VDUpEcEsdxJrqqefJuwTBPhZJf9amPEoKN2/Qh/EqibYzqRNy58Yw==",
+        "requested": "[1.4.6, )",
+        "resolved": "1.4.6",
+        "contentHash": "/8bUlkeVbPRcdtPCdvPfa00HtJbcZtXj89dk6biXK1s2shCntbQQWW9N3t31hARMFOen6F/ViHVWW4Ok+Yh6Pw==",
         "dependencies": {
-          "Corvus.Testing.AzureFunctions.SpecFlow": "1.4.5",
+          "Corvus.Testing.AzureFunctions.SpecFlow": "1.4.6",
           "Microsoft.NET.Test.Sdk": "[16.10.0, 17.0.0)",
           "Moq": "4.16.1",
           "SpecFlow.NUnit.Runners": "3.9.22",
@@ -26,48 +26,47 @@
       },
       "Marain.Services.Tenancy": {
         "type": "Direct",
-        "requested": "[2.2.2, )",
-        "resolved": "2.2.2",
-        "contentHash": "6PytV+UCYuhKWGHYeBrOdbQWz0vhZbsFEq0bepCjAi3ULICYhrhPHKYbGsk7Dw/0jgJrLjVp4kGc2LL2uIxymQ==",
+        "requested": "[2.3.3, )",
+        "resolved": "2.3.3",
+        "contentHash": "Gqo6MqvgdtwCOMeo3gQKk7t1ngDNiBhuF1g0180NUiHQMsxLl8pN0G9p42lKPDL59jbQX573yUgrtE5wU+vLfQ==",
         "dependencies": {
-          "Marain.TenantManagement.Abstractions": "2.2.2",
-          "Menes.Abstractions": "1.2.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12"
+          "Marain.TenantManagement.Abstractions": "2.3.3",
+          "Menes.Abstractions": "2.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.13"
         }
       },
       "Marain.Services.Tenancy.Testing": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "IAsUx1/U0MHXrG+XRMdUoBl6y7Ix7h43QN+7O+JvuzbYtP+q/LCjTkXD+M9FkzScwrufTKOLJD9Z5mDoBL3pEw==",
+        "requested": "[2.3.3, )",
+        "resolved": "2.3.3",
+        "contentHash": "55SKCDTvN7r3+KLtaFt//16axFajzySRLHDO7s4+k/0xNYQ035Q+jb2T7zdhiO7b0mVq2IiefLHMZBYhe9sU6Q==",
         "dependencies": {
-          "Corvus.SpecFlow.Extensions": "0.6.0",
-          "Marain.TenantManagement.Abstractions": "2.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
-          "SpecFlow": "3.3.30"
+          "Corvus.Testing.SpecFlow": "1.3.2",
+          "Marain.TenantManagement.Abstractions": "2.3.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.13"
         }
       },
       "Marain.Tenancy.ClientTenantProvider": {
         "type": "Direct",
-        "requested": "[1.1.2, )",
-        "resolved": "1.1.2",
-        "contentHash": "aWtNXUf66vBFdjc1+eGWLp4uMpBbYSqH2/Wp7pNMvGidbXGFDN2AwsThLXyhuhsYRnRH3+yayO/GN+nVba1pLg==",
+        "requested": "[1.1.15, )",
+        "resolved": "1.1.15",
+        "contentHash": "wlvnIThDewTcjCjeOUR1Ns/Y12AIAMjkG9otVBpIebvSIsCkZXkhEhEGyLtsQkHCbckx8Y2iSyfZo42tHNjoGA==",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Marain.Tenancy.Client": "1.1.2",
+          "Corvus.Tenancy.Abstractions": "2.0.12",
+          "Marain.Tenancy.Client": "1.1.15",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0"
         }
       },
       "Menes.Testing.AspNetCoreSelfHosting": {
         "type": "Direct",
-        "requested": "[1.2.1, )",
-        "resolved": "1.2.1",
-        "contentHash": "LIYQnaKiHnpt6Rn6ju9uIp1kP4fdrZ42g4sKygM3mKelAhlw1tOzq4zBouHii+DkWpN8eW1lLmjYoygll4PU4w==",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "J0SmSXPyocTot3Y5hug3lvi67UTshhBFDP4oicD7axj7EBzCsGQnQHEvm+NZXozg3ZSV42+HIlgU0EFuaMJ5rA==",
         "dependencies": {
-          "Menes.Hosting.AspNetCore": "1.2.1",
+          "Menes.Hosting.AspNetCore": "2.0.1",
           "Microsoft.AspNetCore": "2.2.0",
           "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
-          "Microsoft.Azure.WebJobs": "3.0.25"
+          "Microsoft.Azure.WebJobs": "3.0.27"
         }
       },
       "Microsoft.AspNetCore": {
@@ -120,6 +119,26 @@
         "resolved": "1.5.0",
         "contentHash": "CzIPzdIAFSd2zuLxI+0K9s48Qv3HQDbWiApn9h96j284rHs2bSPrn/PMca3mi4q3xLSEqOp+GUJ6+mXDD9prKg=="
       },
+      "CacheCow.Client": {
+        "type": "Transitive",
+        "resolved": "2.8.3",
+        "contentHash": "hatqwAMz+SPi5I0M7iRu5/d/44oimH7UjwWRGCTRCkWC1MszuZx+C1Geys1SG76vaYy+aXSzwMOnuG7R+JCxAg==",
+        "dependencies": {
+          "CacheCow.Common": "2.8.3",
+          "Microsoft.AspNet.WebApi.Client": "5.2.5",
+          "Microsoft.Extensions.Caching.Memory": "2.0.1",
+          "Newtonsoft.Json": "11.0.1"
+        }
+      },
+      "CacheCow.Common": {
+        "type": "Transitive",
+        "resolved": "2.8.3",
+        "contentHash": "eJF4/Tn2sVza/7c4RJG8CoBTO/nzdyuesDmL8OE28kN8BML47/6A9/UQk1QEpogG7tLgOfEylrSR8rLRYMPn+Q==",
+        "dependencies": {
+          "Microsoft.AspNet.WebApi.Client": "5.2.5",
+          "Newtonsoft.Json": "11.0.1"
+        }
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -156,46 +175,46 @@
       },
       "Corvus.Azure.Cosmos.Tenancy": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "BgD87nmE/DXrE6GVXRKJ8t3DXgeyCuQLJf48xGgfhFmVxkvOOSOPoSxSI4BkcHeZgRTfVUyITOojM4H2XaHs3Q==",
+        "resolved": "2.0.2",
+        "contentHash": "yLJTvsrf5Cg2lQbIpIWMpV56n7b/E2nUz1gWilDtxDvnCAtlo1VUIStHwlFgQ1WnR+RIeyxukOtLCYgs7xFZ7A==",
         "dependencies": {
-          "Corvus.Extensions.CosmosClient": "1.0.5",
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Corvus.Extensions.CosmosClient": "2.0.4",
+          "Corvus.Tenancy.Abstractions": "2.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.13",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.13"
         }
       },
       "Corvus.Azure.Storage.Tenancy": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "frJ6rmdONMMTMd07YXN6GbnhQs+rw9/WWMvG4ThdV8vxTU3v8kCdBcs6SpeaWEksBbWHI5ReOUF+tjKC8gv2Rw==",
+        "resolved": "2.0.13",
+        "contentHash": "naqlx/mpp9OXw0DWQCUMZ93mmyLiLDdk+SSxR9iBMdZXgy/76iO331C5L1Ee24pKizqIq8tmibN35sUr9KN8KA==",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
           "Microsoft.Azure.KeyVault": "3.0.5",
-          "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
-          "Microsoft.Azure.Storage.Blob": "11.2.2",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Microsoft.Azure.Services.AppAuthentication": "1.6.2",
+          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.20"
         }
       },
       "Corvus.ContentHandling": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "O1CJ5Tfv/dFe9y6IOw0EWTnXvDmZe+8cEV1C1RHOv9NwOvxLdp1lHsngxBtcEV41e1jPMqci1ShzFtFB1Wi14Q==",
+        "resolved": "2.0.11",
+        "contentHash": "W4yuYfITGgwPg8KRFlLurwUp9aAsOggedBbtbLPPSmJTJzDK3BMiJnEJh/j0Rc2P37oqv3j8jhf3aOfvn7s5XQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.8.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
+          "Microsoft.CodeAnalysis.CSharp": "3.11.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "System.Runtime.Loader": "4.3.0"
         }
       },
       "Corvus.ContentHandling.Json": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "Nxn2qhw3DqJeX63+TY+PNePqFIwyupocUubsfz70d2Qgk6k66Kx2KBxd5pXotmhQKY2IAw2uxHhWCnGAP/wOVw==",
+        "resolved": "2.0.11",
+        "contentHash": "aYnqiQB7nCe+Pq4szhsdBYRpaXcdZX0u77JL57YAKg/Jfty9p5xVB+9cwi+O7z6boD/xOyYjkr44qMvt06i/ng==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.ContentHandling": "2.0.11",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.5",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -209,13 +228,13 @@
       },
       "Corvus.Extensions.CosmosClient": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "uhwd53ei0YTinBU1xX9Ci9xMGzbecfONhia+xdwDK5o7+oCNnA9HRyoSmQfGZ3+VJaWWqYEFVYDSqfARii/u6Q==",
+        "resolved": "2.0.4",
+        "contentHash": "QhX2y2JhofFQMW+6rxGno8VUD8Zd1fd1o0+pPw3/tsTbRGrTVggx8xhJrzRRxuXKTWWobBGMEP2zW8z+1rwLWg==",
         "dependencies": {
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
-          "Corvus.Retry": "1.0.1",
-          "Microsoft.Azure.Cosmos": "3.16.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
+          "Corvus.Retry": "1.0.2",
+          "Microsoft.Azure.Cosmos": "3.17.0",
           "Microsoft.Azure.KeyVault": "3.0.5",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.Bcl.HashCode": "1.1.1"
@@ -223,11 +242,11 @@
       },
       "Corvus.Extensions.Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "cgnu26gsI09OO7v9KNkgNpKRiWCD27GFE8R2STjyRgVuIGnDaKP5tQlUh3hQS1Rmw0F0fYGSbRGMdAUCwnVd2A==",
+        "resolved": "2.0.6",
+        "contentHash": "6yXJ7xbflSB3c0G7hdNExwlhbEChMRcSn6fX4k8ghhWyADrDSY6jJp9Ce6guxo1c4gVjZwgCVIDhA3JgO8KyHA==",
         "dependencies": {
-          "Corvus.Json.Abstractions": "1.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
+          "Corvus.Json.Abstractions": "2.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -243,94 +262,80 @@
       },
       "Corvus.Json.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "tkj8QDNAKoemvMGLnIHLiuQiaI8DfKpT8T1snqd9/UYzZeIonjjM/MtaJOq5PP+AB3L2h8ZaFA/sgryJMIxsGw=="
+        "resolved": "2.0.6",
+        "contentHash": "ixx72ttlP/Ck+UMWyfiRWVBFKU5XjJySMG33ZWofJp9yy65VF3uOJyGPujr3OedUMo6Uq9umftmHRqhOmUyQ8g=="
       },
       "Corvus.Monitoring.ApplicationInsights": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "tnbCflVOaiN6koeu0zwqwmj0q0W7Nr2f4M7YnQcav0n4IjxZLEVEJx3tZ241naoSl4XPPeHo9pT7zukdOGoDVg==",
+        "resolved": "1.3.2",
+        "contentHash": "Qt3kxNn2r0bSJHbraRc9WxMYwvJnSZfv+tb4tBUYTJQ+eYvGe4cg8HIsRRQcxsPnTJP9dLmfcK7xQ6y0c5ARrg==",
         "dependencies": {
-          "Corvus.Monitoring.Instrumentation.Abstractions": "1.3.1",
+          "Corvus.Monitoring.Instrumentation.Abstractions": "1.3.2",
           "Microsoft.ApplicationInsights": "2.9.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Corvus.Monitoring.Instrumentation.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "ZGQtoehovlD/VhiPIew93LBU1wi3/gqYKFCxC9PGZU7I+/x1d2FD8RM6a6Zk6satmQSttif8eyAXZJDvMOuF+A==",
+        "resolved": "1.3.2",
+        "contentHash": "IEnBaceaj7kJYF96xBusLOQs3GBYaN4TywNzdsNf3Ol7g4NxpCilVSY+mBw1aLbDGm3WapZ2KfaHW7Wo3iWI/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Corvus.Retry": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "aEshkQnOjIJ/F2N0iQHx97A23IeTqqsyIFWBT08gbApr8MUrn8lxpmk5ASpzxCxLUFz+cQiknGbc4etpsorHCA=="
-      },
-      "Corvus.SpecFlow.Extensions": {
-        "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "N6WWrZ1o9SAiyYwrAH1kFWR9CAOpixybOdAcxEt0BU/hYln/D/oaHUfLJNKBNntA2bv2/kB/aGai9br7uVAI1g==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
-          "NUnit": "3.12.0",
-          "SpecFlow": "3.0.225",
-          "System.Management": "4.5.0"
-        }
+        "resolved": "1.0.2",
+        "contentHash": "Jzmv1VpjJnIaz+b0uadkl3yoNh+qnmzHvOcHUXc5oAo1fVqclzxLJAqhOPnm5BVURA5nlqgB3mtmI1YQQhwh9A=="
       },
       "Corvus.Tenancy.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Ooq7Y42DWuX6zJkAADrKUjA9m2O8gVnL8OXVJ79e1qmV/dpA2ek25bfO3PBLKbjuCSGWg2JpwXTd//OKWGhX5A==",
+        "resolved": "2.0.13",
+        "contentHash": "uZxeWtTHYmjI580a+MnrwvgW5KLjhXbDA6o0A5Xo1xPRC3cn2xPXXvfO+ClHtJuyh2bzL8gaWjXyj85N4q5oVg==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Corvus.Tenancy.Storage.Azure.Blob": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "y3pzhj27pjgAYfUhWkI8jhoThkvl9Pi/SFSizYAosQqVNSuE/NSvka4E9kepny5uP9F0LjPBUbfMaWlNyeCwtA==",
+        "resolved": "2.0.13",
+        "contentHash": "dOiRROsPh90WZsejYWSQlIspeC9sGbpzuVFrc+GbfbFoUNvxSpxsFdD2ZNsdOWWE+gBYOIRHMMek1hL2welMTw==",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
-          "Corvus.Tenancy.Abstractions": "1.1.1"
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
+          "Corvus.Tenancy.Abstractions": "2.0.13"
         }
       },
       "Corvus.Testing.AzureFunctions": {
         "type": "Transitive",
-        "resolved": "1.4.5",
-        "contentHash": "cg+Z904qRJr0ZO1zC+kTs4bdJi+HMTFzCNZJB/TR72gZn8nR6HTWUXSsvhjLdtReh3Dc4EKJwq6LErgIXBWlAQ==",
+        "resolved": "1.4.6",
+        "contentHash": "dOoUYwj72I23Egq+FVd5kq+hP2zgw1VdJX1FHoz0ls5n7eBTt9YXHe4rsjNvEZzmQMN1cDv7zoBXX1jGiIB1dg==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.19",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
           "System.Management": "4.7.0"
         }
       },
       "Corvus.Testing.AzureFunctions.SpecFlow": {
         "type": "Transitive",
-        "resolved": "1.4.5",
-        "contentHash": "XM033EbN++ehztEEPTugkDTOAg5nzGwR9rt6vRQpxRkkSeunerENIo7TWmKxLvvweV+VjFo3w/JsrUQtBXI96A==",
+        "resolved": "1.4.6",
+        "contentHash": "kNwjluoe+fTid58d2YOGCgYbw3eWRqItC8HQ5N4rGsl4ZjuG1IOeFP/zjCG96NllRRVDRYoNguEQIregT04bnQ==",
         "dependencies": {
-          "Corvus.Testing.AzureFunctions": "1.4.5",
-          "Corvus.Testing.SpecFlow": "1.4.5",
-          "Microsoft.Extensions.Logging.Console": "3.1.19",
+          "Corvus.Testing.AzureFunctions": "1.4.6",
+          "Corvus.Testing.SpecFlow": "1.4.6",
+          "Microsoft.Extensions.Logging.Console": "3.1.20",
           "NUnit": "3.13.2",
           "SpecFlow": "3.9.22"
         }
       },
       "Corvus.Testing.SpecFlow": {
         "type": "Transitive",
-        "resolved": "1.4.5",
-        "contentHash": "wECzJlyMgoKZv6fI0y69IDs8oZ20FoZ2vluJqg5uID8shy+HmzN86ZG7rKXxZUyqSmszKoNrF23zNrr4v8545w==",
+        "resolved": "1.4.6",
+        "contentHash": "EmakRYEWtLqOXJXV8vOq4bOikivszKcclnRClM65IULefSCY1Cm+pP5wvJusetZWRQ7xXjvI9Hzp25T1MJmVBQ==",
         "dependencies": {
-          "Corvus.Testing.AzureFunctions": "1.4.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "NUnit": "3.13.2",
           "SpecFlow": "3.9.22",
           "System.Management": "4.7.0"
@@ -364,58 +369,59 @@
       },
       "Marain.Tenancy.Client": {
         "type": "Transitive",
-        "resolved": "1.1.2",
-        "contentHash": "770vE+oTJ2/U9ouAVhv92e+YqKuL/q4ZotSOoKL/qZ9SByOcmtH5w7k+biBiXLTAsq2hupUed8m3IY+CqnogNQ==",
+        "resolved": "1.1.15",
+        "contentHash": "7n4jJ5PM1ZlxioQhw8LBPF7xYtFwb4GstPby/Qei8EGxE4HG++uzSDBVG+8TDMmrfR/UA1GuiP6M1VIgaHlgTA==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.3",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
-          "Microsoft.Rest.ClientRuntime": "2.3.22"
+          "CacheCow.Client": "2.8.3",
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Rest.ClientRuntime": "2.3.23"
         }
       },
       "Marain.TenantManagement.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.2",
-        "contentHash": "0cEk4QkHeZ7KOy7jLxC45ajbtQb3kGWRI0RUQeoNNPpXJ7sc1QLCFM6yuxOfeJr4uGoGT6/I5TW1r7cpNpOrKQ==",
+        "resolved": "2.3.3",
+        "contentHash": "CBBYF1RSNITOssgphcvUimlkFbn1/7yUXY+iohgapzG3DLAcsfqft6/IPseX+3s4nlL/Mcfsx3hwKbjWMRRiqQ==",
         "dependencies": {
-          "Corvus.Azure.Cosmos.Tenancy": "1.1.1",
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Microsoft.Extensions.Logging": "3.1.12"
+          "Corvus.Azure.Cosmos.Tenancy": "2.0.2",
+          "Corvus.Azure.Storage.Tenancy": "2.0.2",
+          "Corvus.Tenancy.Abstractions": "2.0.2",
+          "Microsoft.Extensions.Logging": "3.1.13"
         }
       },
       "Menes.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "H6Q4P6LVCJzXepyrvFYallQy8refCBOdlp1ymXJxBVkYSX9iQJFYvc0PSUVY6QPLKS9svE59kecVMFpgGgDUcw==",
+        "resolved": "2.0.1",
+        "contentHash": "uNJTJhw3gHx2NYuQUt8YV/UGtPhqzvN+Xh1QWLia0ZmUByNJ19GcDtCE4pPfabnPp2eL23NhJUN7UvhWWeUNog==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
+          "Corvus.ContentHandling": "2.0.4",
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
           "Corvus.Monitoring.Instrumentation.Abstractions": "1.2.0",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Logging": "3.1.12",
+          "Microsoft.Extensions.Logging": "3.1.13",
           "Microsoft.OpenApi.Readers": "1.2.3",
           "System.Interactive": "4.1.1",
-          "System.Text.Encodings.Web": "4.7.1",
+          "System.Text.Encodings.Web": "4.7.2",
           "Tavis.UriTemplates": "1.1.1"
         }
       },
       "Menes.Hosting": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "n82LVUCzHph96w8X7LjQP88Pj2QNFxJ3EmSYLlL7jIgdFdKhHYQqc1NXiLGcLQwLTtfvIxbvpQAxhAlOzPBLJw==",
+        "resolved": "2.0.1",
+        "contentHash": "wRXHxNfI9Bwl7Qnpz74HfZeDNFSjMHBNjXmpn7yuErxtP8ujjGxqZEOdiPPQ457N4prmShbOVPaYtQVdbaXnNw==",
         "dependencies": {
-          "Menes.Abstractions": "1.2.1"
+          "Menes.Abstractions": "2.0.1"
         }
       },
       "Menes.Hosting.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "4a3OAXeVUi+mhB2JeIaRPlqut5QE9CQxol9RiUM7C3SjEMhQDVOZJxJqILIEj/Q59khYzRmLScNira5ECymdmg==",
+        "resolved": "2.0.1",
+        "contentHash": "Zpzf8AHD7BQ7gOBe52Dw+tcZc+eh/7HLrCe9YHkw5PqjaF6SpvMfSpKowSTJLF1p5CVqQIxuNIyITl2/rYTDJQ==",
         "dependencies": {
-          "Menes.Hosting": "1.2.1",
+          "Menes.Hosting": "2.0.1",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -430,8 +436,8 @@
       },
       "Microsoft.AspNet.WebApi.Client": {
         "type": "Transitive",
-        "resolved": "5.2.4",
-        "contentHash": "OdBVC2bQWkf9qDd7Mt07ev4SwIdu6VmLBMTWC0D5cOP/HWSXyv/77otwtXVrAo42duNjvXOjzjP5oOI9m1+DTQ==",
+        "resolved": "5.2.5",
+        "contentHash": "ie1BsWwmdD9n3DDhVqEmV0A5UohtBsPFHNL2YPT3KUynBZN8iNaLsRtQwMFg/TVcjiZYAh1sCdMYW7I9DQTLww==",
         "dependencies": {
           "Newtonsoft.Json": "10.0.1",
           "Newtonsoft.Json.Bson": "1.0.1"
@@ -794,8 +800,8 @@
       },
       "Microsoft.Azure.Cosmos": {
         "type": "Transitive",
-        "resolved": "3.16.0",
-        "contentHash": "8CVDpwJcGlD1ehuKde5Uju0gjeIcDQIq5xmhE8VnrWH1DjzZ3nJ2uGVMqCj7G8XYkxTR9m42E7wREOEbMYF++g==",
+        "resolved": "3.17.0",
+        "contentHash": "SDUIpfOWKiE+RMe9RcaxatmSlzC+MqC0hRInEWqU9n0ntG1M2Hv/0IT5He6LQMe2io59gxUvMHuIZe9Dih8hjw==",
         "dependencies": {
           "Azure.Core": "1.3.0",
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
@@ -898,10 +904,10 @@
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "78AcjpxnhJDov7HJa4kPpZxpI0coZhS0tdA9ZLUSPExKz5KTgfozayBTLAXDuTuq0gLRzFyf85SvIkrtbB8KpA==",
+        "resolved": "1.6.2",
+        "contentHash": "rSQhTv43ionr9rWvE4vxIe/i73XR5hoBYfh7UUgdaVOGW1MZeikR9RmgaJhonTylimCcCuJvrU0zXsSIFOsTGw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
           "System.Diagnostics.Process": "4.3.0"
         }
       },
@@ -926,26 +932,27 @@
       },
       "Microsoft.Azure.WebJobs": {
         "type": "Transitive",
-        "resolved": "3.0.25",
-        "contentHash": "sIL3t9ObUFY2IBtjgeqgaw6wrjlXa3jVsjBevLX/cw9zDr5PSzD+y3/szPHcyHYbWVgn+LsFxo4xExNDwjg95g==",
+        "resolved": "3.0.27",
+        "contentHash": "Bj0qhJeGBejVi/XG9wj5ZpJP8iqia+hBSiZ3+x0pkyYeCKEj4wOqacGBQ83/0FAKhf4aib86ZfHei29u92qlzw==",
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.25",
-          "Microsoft.Extensions.Configuration": "2.1.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.1.0",
+          "Microsoft.Azure.WebJobs.Core": "3.0.27",
+          "Microsoft.Extensions.Configuration": "2.1.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "2.1.1",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.0",
           "Microsoft.Extensions.Configuration.Json": "2.1.0",
           "Microsoft.Extensions.Hosting": "2.1.0",
-          "Microsoft.Extensions.Logging": "2.1.0",
-          "Microsoft.Extensions.Logging.Abstractions": "2.1.0",
+          "Microsoft.Extensions.Logging": "2.1.1",
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "11.0.2",
+          "System.Memory.Data": "1.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         }
       },
       "Microsoft.Azure.WebJobs.Core": {
         "type": "Transitive",
-        "resolved": "3.0.25",
-        "contentHash": "dwW5+Y7UNBql88d1eQT5/XUk6FXOAgofgHBguzBnTo0M87QZKwwrzEqy92af1xKxgzvU4TInyZXMbLMf0C9WCw==",
+        "resolved": "3.0.27",
+        "contentHash": "WgbFYX5I0t7NX6hT9ydnU76tyDuggX6jCfs/GgIURTBkKv3co0Co9cb8aQhHejuCs04bCIdvYY/nAzdBT0oUlw==",
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0"
@@ -1008,29 +1015,29 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "ojG5pGAhTPmjxRGTNvuszO3H8XPZqksDwr9xLd4Ae/JBjZZdl6GuoLk7uLMf+o7yl5wO0TAqoWcEKkEWqrZE5g=="
+        "resolved": "3.3.2",
+        "contentHash": "7xt6zTlIEizUgEsYAIgm37EbdkiMmr6fP6J9pDoKEpiGM4pi32BCPGr/IczmSJI9Zzp0a6HOzpr9OvpMP+2veA=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "8YTZ7GpsbTdC08DITx7/kwV0k4SC6cbBAFqc13cOm5vKJZcEIAh51tNSyGSkWisMgYCr96B2wb5Zri1bsla3+g==",
+        "resolved": "3.11.0",
+        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
           "System.Memory": "4.5.4",
           "System.Reflection.Metadata": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.7.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
           "System.Text.Encoding.CodePages": "4.5.1",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "hKqFCUSk9TIMBDjiYMF8/ZfK9p9mzpU+slM73CaCHu4ctfkoqJGHLQhyT8wvrYsIg+ufrUWBF8hcJYmyr5rc5Q==",
+        "resolved": "3.11.0",
+        "contentHash": "aDRRb7y/sXoJyDqFEQ3Il9jZxyUMHkShzZeCRjQf3SS84n2J0cTEi3TbwVZE9XJvAeMJhGfVVxwOdjYBg6ljmw==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.8.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
       "Microsoft.CodeCoverage": {
@@ -1075,44 +1082,44 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "kGMEV53Od1ES0BDh7OOKbTW9Zu5dbbQ72yI936dvvbHlde3puuq/WRKAccFgcB2PuRjox1HFhA9+t53RYqfuEA==",
+        "resolved": "2.0.1",
+        "contentHash": "NobDNbehAbMYUApMXLd9XSt9UznGCgPW9PW4Ybe6S5jKqkd5RcTnaKm0FODcgyx+7B1hIGx7dZwa1bVdiSbHAg==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "2.0.0"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "NqvVdYLbX7N2J2Wz9y3zjhE66JRdROiZZsGhA2u4a9IcIq/jzINC/cLM96BHA+TSOZFPxVdWneqB6/yt9u846A==",
+        "resolved": "2.0.1",
+        "contentHash": "GVtJD0uhoLOkXBfYZAIRDexEr2qg0QHbUo3CIjmtoGpFWHuGHTvjGqRlybMKIYTpt0BxKpXMn4fqhS4ff10llA==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "2.0.0",
+          "Microsoft.Extensions.Caching.Abstractions": "2.0.1",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0",
-          "Microsoft.Extensions.Options": "2.0.0"
+          "Microsoft.Extensions.Options": "2.0.1"
         }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "KDfhqlop17pf6zSOzcIydwXNFI8T15Sg7vguGvf9cjPpXCSNSvuWjVpZB+T9KAGQT7mbrB2W0GOYl/1Kgre/7Q==",
+        "resolved": "3.1.20",
+        "contentHash": "qN871hvjHs9pqVW1E8dXzww3hDXmAtSC0Mjvht+2choJN+KKLL/mQpX2Egkp9Wvox005bfmBrFW7svDDTjmuoQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "5XARAKFFAlX6WVk/c2/oAW44Oh0TMYwIFJJqxjkFXjPWsZAFuPTD0yLuaXvnILATpR8guks4V8yTE33HaV7ZOg==",
+        "resolved": "3.1.20",
+        "contentHash": "TpevBA1qF8XuuP5md8As81SHfhtAsVocH/i76F1WjYoOBpA9nwC3dmpN/YDi89efRzU6qk5AYvZ1ldCONtAYSQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "UmyDTRQWG1RaP70rGlymCWlDKK9ZHvypJocinplxeeky3bevDBdI4qnhT0eXQSu/iRlanXvhoyBimh9glXPJjg==",
+        "resolved": "3.1.20",
+        "contentHash": "eS6Q5oRKmBQKlgIjSXmgaF2jwSAuii+3UjTSN4jI2LH1N0utPNgZNtnOVXDU2tZiUOtQuAROBb8PZKgHgIgsYQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
@@ -1160,16 +1167,16 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "cdBicT5kRGBVWilW0QUFYmeqYNgBP3NHwrnsuJj0QqivA74OHcUiS18EFLMRmqwZ746mbnptfSZ4Lh997KsUew==",
+        "resolved": "3.1.20",
+        "contentHash": "JAV97hx4y7qJ5mnjnUOSd+xDnMj2+51c8KVirhuU+rOW1LUnsmjhin86Tep6Q5tOHmNPOmmo6OHEFCdbZj5+zw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "tiaohUQoNWfUQBWAW4wg9yRYAYcxq0IERI6bR8DojusFIVybdzOJ1bJXLghfO17cGx05SdiUnUk8h0SiQn0hBw=="
+        "resolved": "3.1.20",
+        "contentHash": "a2axLm7TfsB6rELiYDp7qx0S64h1FCFAFGz0WnPWgyshpvLWYM/XKwLHIPqiXuhtEp9kT4qBXRYsXMe6ZrxX0A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -1202,8 +1209,8 @@
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Htid3HfJu6W5KInQvN31ku2JHU9R0Oy4wlv22M7Paj9x1gjeEx3mhpPVgclnAm/2OCo+b9ZTqwUZD7Mx3lXuBQ=="
+        "resolved": "3.1.20",
+        "contentHash": "2Sz4v3iuv1ZXVxz2/SfdaDVsfbeHirmlFp2zcguyS9IHh2ZxnCzMOLjvmkf+vt/XFRQaIFIDepushHdkif4xsQ=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Transitive",
@@ -1230,37 +1237,37 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Wv/p90AEtp69cPuQQKAFQCS2tIefqaT6elTx3AwLgltkDXvzGVPbXI7NcfOWh3TNdDcfwV7U6YFC0WrNVA88WA==",
+        "resolved": "3.1.20",
+        "contentHash": "/CuUfjdPd0X6upL/783pzJTSGLm1XTHlonKcRYi5oGVHuN0ESHRjWwmBvrAPf8TXXL901K9oyxJ9mtG9pTmF8Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection": "3.1.19",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Options": "3.1.19"
+          "Microsoft.Extensions.Configuration.Binder": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection": "3.1.20",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options": "3.1.20"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "ZJxpOfelPknOpD+/P+vcvXXAo7JVwBu2n/NkTuQzwneVzqJFzXB4lJu/jr4sbMIrTNvJi/XixPHrKcaztVkXSQ=="
+        "resolved": "3.1.20",
+        "contentHash": "pejtJ+FM3tRm9Ssy9VO1PMkxlpkwbO+iQmK/Ot9DqgW3zjeLSQg3bEPI6klU70yoRSDwpiI8E71RdzU+vn/bTQ=="
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "7OCff9UJ9j20HM+6DkyshiSTQHJP4l0+CmNattTYqNO1kRxwupSnwfIAwWDEYj4cX1Wpp3sfTGbu92hjF625nw==",
+        "resolved": "3.1.20",
+        "contentHash": "+k33hBevAq2hZi4tHnsQwtZDXAkD79MTntOvX5ID6kMgU6piqthMLMoK5uMJAh7vec8ORMhwSIkhjYaQ7wx4gw==",
         "dependencies": {
-          "Microsoft.Extensions.Logging": "3.1.19",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.19"
+          "Microsoft.Extensions.Logging": "3.1.20",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.20"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "qofNSCPx5RkwsVbt8Y2QizHAx5iYDWxaXHvsXcRHtHZfJ/nnq08zjORcQ6zZUfNqyEWYZAoTfgv9gCWN59BodA==",
+        "resolved": "3.1.20",
+        "contentHash": "v9GpjBR3YBNSnbNj1C4hQmRofUDpya1CgQwZo3IuXbun2JbSmHs1sVxuMyEh8sdU7Bo8gGyA3zdtEwE+16oiVA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Logging": "3.1.19",
-          "Microsoft.Extensions.Logging.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Logging": "3.1.20",
+          "Microsoft.Extensions.Logging.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Logging.Debug": {
@@ -1287,39 +1294,40 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "awGsLKbgxb/3jxmKQQpD2aPAsWW//d8MTQfFB2XgU2xnjLCx+GN5EPdLe6GfB9ulMq/2AiqZ3IXciHBzSGQ1Uw==",
+        "resolved": "3.1.20",
+        "contentHash": "K5h3xUrYP8mbGZeGAm/vcWjol2wBh2V1vV+Vz02DCKlZ/99Y8ecKJwdpH+elfdqcEFXy76jk+I1nBsmhPKeCgw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "wcPJBm5oKhGLYoTzN8CQIDrLvDCAHxI5JZXQbHNcsKmuc5JYO+I/iTGqnJ7UPw40HI4YhvsnwooeMsJZdHQGWg==",
+        "resolved": "3.1.20",
+        "contentHash": "vmh27AY00NDg6+4P5NbLnhKsrNMBtfcFAoE0Pim7yNAB46ev44vu2O5a3AINUoRl9Kovik72Wgn8qA4IpQu+vg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Configuration.Binder": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Options": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Configuration.Binder": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options": "3.1.20"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Al3SuZLS4nN7o3TQPfJGHNnQuLEKXz/tBXoPeESMnJxRLCWomo9MAdjEBunexaWK4as+ESVqOD2rLVyBBx3/qA=="
+        "resolved": "3.1.20",
+        "contentHash": "RHHWUHzW8y+dyNBIBmo2EQbpCC6xFQcFMpLhNcpzw3zP0rxJdhmTTdy5eXvhlkNi3vqM4Af5Qqb5xgYwqaoaJQ=="
       },
       "Microsoft.IdentityModel.Clients.ActiveDirectory": {
         "type": "Transitive",
-        "resolved": "5.2.0",
-        "contentHash": "5zCom0plcWSAuPp2B/Fo7XFKdrPUOaE+1dhVW5Ui2Gny7YYv1fDJ1Z8GeZEJuCd3rKN4UBO834wPEhU5gIPQMw==",
+        "resolved": "5.2.9",
+        "contentHash": "WhBAG/9hWiMHIXve4ZgwXP3spRwf7kFFfejf76QA5BvumgnPp8iDkDCiJugzAcpW1YaHB526z1UVxHhVT1E5qw==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0",
           "NETStandard.Library": "1.6.1",
           "System.ComponentModel.TypeConverter": "4.3.0",
           "System.Dynamic.Runtime": "4.3.0",
           "System.Net.Http": "4.3.4",
+          "System.Private.Uri": "4.3.2",
           "System.Runtime.Serialization.Formatters": "4.3.0",
           "System.Runtime.Serialization.Json": "4.3.0",
           "System.Runtime.Serialization.Primitives": "4.3.0",
@@ -1391,8 +1399,8 @@
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+        "resolved": "1.1.3",
+        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
       },
       "Microsoft.OData.Core": {
         "type": "Transitive",
@@ -1520,8 +1528,8 @@
       },
       "NETStandard.Library": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "7jnbRU+L08FXKMxqUflxEXtVymWvNOrS8yHgu9s6EM8Anr6T/wIX4nZ08j/u3Asz+tCufp3YVwFSEvFTPYmBPA==",
+        "resolved": "2.0.1",
+        "contentHash": "oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -2172,6 +2180,14 @@
         "resolved": "4.5.4",
         "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
       },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "1.0.1",
+        "contentHash": "ujvrOjcni2QQbr6hG2AkUTWLb/xplrx0mt6HrdHFCzzGky2d5J6YD60TKAEf8SBk33cfSzTvFmXewAVaPY/dZg==",
+        "dependencies": {
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "System.Net.Http": {
         "type": "Transitive",
         "resolved": "4.3.4",
@@ -2395,6 +2411,15 @@
           "System.Xml.XmlSerializer": "4.3.0"
         }
       },
+      "System.Private.Uri": {
+        "type": "Transitive",
+        "resolved": "4.3.2",
+        "contentHash": "o1+7RJnu3Ik3PazR7Z7tJhjPdE000Eq2KGLLWhqJJKXj04wrS8lwb1OFtDF9jzXXADhUuZNJZlPc98uwwqmpFA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
       "System.Reflection": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2501,8 +2526,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -2830,8 +2855,13 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "3qreYFQcLnyFk1LuaNWyyWE+sfkfe5eSTaIIssYrLNUIDbgyZNQBYQSzSDo4AprpjVeVX2T4KHKii9fiSZVUow=="
+        "resolved": "4.7.2",
+        "contentHash": "iTUgB/WtrZ1sWZs84F2hwyQhiRH6QNjQv2DkwrH+WP6RoFga2Q1m3f9/Q7FG8cck8AdHitQkmkXSY8qylcDmuA=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "4.6.0",
+        "contentHash": "4F8Xe+JIkVoDJ8hDAZ7HqLkjctN/6WItJIzQaifBwClC7wmoLSda/Sv2i6i1kycqDb3hWF4JCVbpAweyOKHEUA=="
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -3038,8 +3068,8 @@
       "marain.claims.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Menes.Abstractions": "1.2.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
+          "Menes.Abstractions": "2.0.1",
           "Microsoft.Extensions.FileSystemGlobbing": "3.1.0",
           "Newtonsoft.Json": "12.0.3"
         }
@@ -3075,13 +3105,13 @@
         "type": "Project",
         "dependencies": {
           "Corvus.Identity.ManagedServiceIdentity.ClientAuthentication": "1.0.7",
-          "Corvus.Monitoring.ApplicationInsights": "1.3.1",
-          "Corvus.Tenancy.Storage.Azure.Blob": "1.1.1",
+          "Corvus.Monitoring.ApplicationInsights": "1.3.2",
+          "Corvus.Tenancy.Storage.Azure.Blob": "2.0.13",
           "Marain.Claims.OpenApi": "1.0.0",
           "Marain.Claims.OpenApi.AspNetCore": "1.0.0",
           "Marain.Claims.OpenApi.Service": "1.0.0",
           "Marain.Claims.Tenancy.AzureBlob": "1.0.0",
-          "Marain.Tenancy.ClientTenantProvider": "1.1.2"
+          "Marain.Tenancy.ClientTenantProvider": "1.1.15"
         }
       },
       "marain.claims.openapi": {
@@ -3093,7 +3123,7 @@
       "marain.claims.openapi.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
+          "Corvus.ContentHandling.Json": "2.0.11",
           "Marain.Claims.OpenApi": "1.0.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "System.IdentityModel.Tokens.Jwt": "5.5.0"
@@ -3102,9 +3132,9 @@
       "marain.claims.openapi.service": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
           "Marain.Claims.Abstractions": "1.0.0",
-          "Marain.Services.Tenancy": "2.2.2",
+          "Marain.Services.Tenancy": "2.3.3",
           "Microsoft.ApplicationInsights": "2.18.0",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.0"
@@ -3114,7 +3144,7 @@
         "type": "Project",
         "dependencies": {
           "Corvus.Extensions": "1.1.4",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.6",
           "Marain.Claims.Abstractions": "1.0.0",
           "Microsoft.Azure.Storage.Blob": "11.2.3"
         }
@@ -3122,10 +3152,10 @@
       "marain.claims.tenancy.azureblob": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
           "Marain.Claims.OpenApi": "1.0.0",
           "Marain.Claims.Storage.AzureBlob": "1.0.0",
-          "Menes.Hosting.AspNetCore": "1.2.1",
+          "Menes.Hosting.AspNetCore": "2.0.1",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.0"
         }

--- a/Solutions/Marain.Claims.SetupTool/packages.lock.json
+++ b/Solutions/Marain.Claims.SetupTool/packages.lock.json
@@ -54,10 +54,10 @@
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "cdBicT5kRGBVWilW0QUFYmeqYNgBP3NHwrnsuJj0QqivA74OHcUiS18EFLMRmqwZ746mbnptfSZ4Lh997KsUew==",
+        "resolved": "3.1.20",
+        "contentHash": "JAV97hx4y7qJ5mnjnUOSd+xDnMj2+51c8KVirhuU+rOW1LUnsmjhin86Tep6Q5tOHmNPOmmo6OHEFCdbZj5+zw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Rest.ClientRuntime.Azure.Authentication": {
@@ -107,39 +107,39 @@
       },
       "Corvus.ContentHandling": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "O1CJ5Tfv/dFe9y6IOw0EWTnXvDmZe+8cEV1C1RHOv9NwOvxLdp1lHsngxBtcEV41e1jPMqci1ShzFtFB1Wi14Q==",
+        "resolved": "2.0.11",
+        "contentHash": "W4yuYfITGgwPg8KRFlLurwUp9aAsOggedBbtbLPPSmJTJzDK3BMiJnEJh/j0Rc2P37oqv3j8jhf3aOfvn7s5XQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.8.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
+          "Microsoft.CodeAnalysis.CSharp": "3.11.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "System.Runtime.Loader": "4.3.0"
         }
       },
       "Corvus.ContentHandling.Json": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "Nxn2qhw3DqJeX63+TY+PNePqFIwyupocUubsfz70d2Qgk6k66Kx2KBxd5pXotmhQKY2IAw2uxHhWCnGAP/wOVw==",
+        "resolved": "2.0.11",
+        "contentHash": "aYnqiQB7nCe+Pq4szhsdBYRpaXcdZX0u77JL57YAKg/Jfty9p5xVB+9cwi+O7z6boD/xOyYjkr44qMvt06i/ng==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.ContentHandling": "2.0.11",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.5",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Corvus.Extensions": {
         "type": "Transitive",
-        "resolved": "1.1.2",
-        "contentHash": "OTUxQ2P8r3+xORMWhDvryJZhvOfCDbSYjTBfTm7p5RcpXrEIxFpfhjxfSESzwKfek9AZVnmc9M8j0l7UnnETMg==",
+        "resolved": "1.1.4",
+        "contentHash": "WGwNzQDNrlxfH82iRSSXcG92yKhE8xlBMWoSC4dycp0MnH2Mle0TF+Y4keRgDAdDwXg8VC+3paZx64jVG1Jazg==",
         "dependencies": {
           "System.Interactive": "3.2.0"
         }
       },
       "Corvus.Extensions.Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "cgnu26gsI09OO7v9KNkgNpKRiWCD27GFE8R2STjyRgVuIGnDaKP5tQlUh3hQS1Rmw0F0fYGSbRGMdAUCwnVd2A==",
+        "resolved": "2.0.5",
+        "contentHash": "d9g6XjfyU5z2gffGNuOD4veWzCEUibioxvYyQkiwOmt+0SL5M0j4C6TNE6015LzEVYtnjLHXM+3op3NUqLtK7g==",
         "dependencies": {
-          "Corvus.Json.Abstractions": "1.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
+          "Corvus.Json.Abstractions": "2.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -155,8 +155,8 @@
       },
       "Corvus.Json.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "tkj8QDNAKoemvMGLnIHLiuQiaI8DfKpT8T1snqd9/UYzZeIonjjM/MtaJOq5PP+AB3L2h8ZaFA/sgryJMIxsGw=="
+        "resolved": "2.0.5",
+        "contentHash": "fUuuUwktUoCQNwR2+bvi2AcOPzJkU51o8Js37vCTdXBg4aDLQZaFIuyO9Dg9Sm9NW1hVhK5nBFkBaqbmF5rutg=="
       },
       "Corvus.Monitoring.Instrumentation.Abstractions": {
         "type": "Transitive",
@@ -168,28 +168,28 @@
       },
       "Corvus.Tenancy.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Ooq7Y42DWuX6zJkAADrKUjA9m2O8gVnL8OXVJ79e1qmV/dpA2ek25bfO3PBLKbjuCSGWg2JpwXTd//OKWGhX5A==",
+        "resolved": "2.0.13",
+        "contentHash": "uZxeWtTHYmjI580a+MnrwvgW5KLjhXbDA6o0A5Xo1xPRC3cn2xPXXvfO+ClHtJuyh2bzL8gaWjXyj85N4q5oVg==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Menes.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "H6Q4P6LVCJzXepyrvFYallQy8refCBOdlp1ymXJxBVkYSX9iQJFYvc0PSUVY6QPLKS9svE59kecVMFpgGgDUcw==",
+        "resolved": "2.0.1",
+        "contentHash": "uNJTJhw3gHx2NYuQUt8YV/UGtPhqzvN+Xh1QWLia0ZmUByNJ19GcDtCE4pPfabnPp2eL23NhJUN7UvhWWeUNog==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
+          "Corvus.ContentHandling": "2.0.4",
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
           "Corvus.Monitoring.Instrumentation.Abstractions": "1.2.0",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Logging": "3.1.12",
+          "Microsoft.Extensions.Logging": "3.1.13",
           "Microsoft.OpenApi.Readers": "1.2.3",
           "System.Interactive": "4.1.1",
-          "System.Text.Encodings.Web": "4.7.1",
+          "System.Text.Encodings.Web": "4.7.2",
           "Tavis.UriTemplates": "1.1.1"
         }
       },
@@ -289,29 +289,29 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "ojG5pGAhTPmjxRGTNvuszO3H8XPZqksDwr9xLd4Ae/JBjZZdl6GuoLk7uLMf+o7yl5wO0TAqoWcEKkEWqrZE5g=="
+        "resolved": "3.3.2",
+        "contentHash": "7xt6zTlIEizUgEsYAIgm37EbdkiMmr6fP6J9pDoKEpiGM4pi32BCPGr/IczmSJI9Zzp0a6HOzpr9OvpMP+2veA=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "8YTZ7GpsbTdC08DITx7/kwV0k4SC6cbBAFqc13cOm5vKJZcEIAh51tNSyGSkWisMgYCr96B2wb5Zri1bsla3+g==",
+        "resolved": "3.11.0",
+        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
           "System.Memory": "4.5.4",
           "System.Reflection.Metadata": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.7.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
           "System.Text.Encoding.CodePages": "4.5.1",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "hKqFCUSk9TIMBDjiYMF8/ZfK9p9mzpU+slM73CaCHu4ctfkoqJGHLQhyT8wvrYsIg+ufrUWBF8hcJYmyr5rc5Q==",
+        "resolved": "3.11.0",
+        "contentHash": "aDRRb7y/sXoJyDqFEQ3Il9jZxyUMHkShzZeCRjQf3SS84n2J0cTEi3TbwVZE9XJvAeMJhGfVVxwOdjYBg6ljmw==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.8.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
       "Microsoft.CSharp": {
@@ -339,67 +339,67 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "sQeNlafyb7XIYubfELbAQtN3U7DubZEs8d7xaj09sAdD929spOqiZKHcWpEQDtWtwqXm70JWS1WDfxpOvuVMcw==",
+        "resolved": "3.1.13",
+        "contentHash": "zuvjW34EpCfGrpDe6e9o/8xJ5idf2PnejmGiPjBQesdw32yBOaegTwLmPtoW70RUIYr58j8EDGf7yTaFSc6KXA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.12"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.13"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "LMq236lxH1ji2FYv+2o6A9Nfb9jrDWl6Dn1XleA473NmBfYf/93MfPBgmnJA1qlFQPt9BKBd3r3h7NaTbDcHMw==",
+        "resolved": "3.1.13",
+        "contentHash": "WuU1zMRpNrRihLP0HAwm5rWqgdJUywESu3e38FDRsnx2V/FlN+tOf04bZNnimKmFfwF+wdsxlQjKBBye6EEOZw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Microsoft.Extensions.Primitives": "3.1.13"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "tso2dQMzmtALku0vMB6VuZpxDD6HYXqut+a8FdaU8XelnlR0aCi/LsK6Ej7VZbkKBqTQSgHAwyghbuKhk1sxog==",
+        "resolved": "3.1.13",
+        "contentHash": "hZJvreLS8ByBboruPMJ0oFJ2gV6NQ0MrSYAeoACjKzRVgGZp6SGdpIG8A2Ar+BqkLlVBxGh8MxvrDwL1x8v6oA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.12"
+          "Microsoft.Extensions.Configuration": "3.1.13"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "tiaohUQoNWfUQBWAW4wg9yRYAYcxq0IERI6bR8DojusFIVybdzOJ1bJXLghfO17cGx05SdiUnUk8h0SiQn0hBw=="
+        "resolved": "3.1.20",
+        "contentHash": "a2axLm7TfsB6rELiYDp7qx0S64h1FCFAFGz0WnPWgyshpvLWYM/XKwLHIPqiXuhtEp9kT4qBXRYsXMe6ZrxX0A=="
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Htid3HfJu6W5KInQvN31ku2JHU9R0Oy4wlv22M7Paj9x1gjeEx3mhpPVgclnAm/2OCo+b9ZTqwUZD7Mx3lXuBQ=="
+        "resolved": "3.1.20",
+        "contentHash": "2Sz4v3iuv1ZXVxz2/SfdaDVsfbeHirmlFp2zcguyS9IHh2ZxnCzMOLjvmkf+vt/XFRQaIFIDepushHdkif4xsQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "EXwfP6M/G6mwM/f9eVNY3tOnY539gIEjeSXs2G/RtuGILteW455ZLxfZmE7qzWSc0J2wvoMuxdkB+WMsBW8Kqw==",
+        "resolved": "3.1.13",
+        "contentHash": "CjerR5jL1J3lxjFrrqaw+p8uIK95gulacGKOgMoYSpaF5QB9TISYE8R2WUvVOxa2n0LxQpp9cvVoFof5JAg5ow==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "3.1.12",
-          "Microsoft.Extensions.DependencyInjection": "3.1.12",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options": "3.1.12"
+          "Microsoft.Extensions.Configuration.Binder": "3.1.13",
+          "Microsoft.Extensions.DependencyInjection": "3.1.13",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.13",
+          "Microsoft.Extensions.Options": "3.1.13"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "Ixi6qAF3sr1FjPntVamRCMcnrCPx6l0G8VxtVshEk4n8lGs0Hj62jmt/xJ4mHrxR5ST0T49ERT2HsJcv6z+wGw=="
+        "resolved": "3.1.13",
+        "contentHash": "FUGJ/9dIYzTwHDtKK/MVOAAC1mt7L1ZczmbpJigUjWK6ECJV5v4bbo8dlsKIUqN4Wal3DwEo7BzTdK8GEdi5tg=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "by2/frdg182EdpUkFw+2+h+POQTUCVNZRGWgFZKKZhxfuN+hJZFAaGMAuo1ouLexMa1PGTqWAgw/zaZ2WwU71Q==",
+        "resolved": "3.1.13",
+        "contentHash": "+dGzq7kEkKCRO5kJ6JruOTbIk442OyB53mktUVmpgb9a5uFgv2WyZKWdN+uMJJQvY4bW+k5OJD5J6jA+DwX78w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Primitives": "3.1.12"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.13",
+          "Microsoft.Extensions.Primitives": "3.1.13"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "QjEKb7QWbk44/t05BKlYaHP1sX2jOW9MypKVeMikX6932J34AioVo9heppJ8XAUpBLL15iOiyncSLWgHE32xMg=="
+        "resolved": "3.1.20",
+        "contentHash": "RHHWUHzW8y+dyNBIBmo2EQbpCC6xFQcFMpLhNcpzw3zP0rxJdhmTTdy5eXvhlkNi3vqM4Af5Qqb5xgYwqaoaJQ=="
       },
       "Microsoft.IdentityModel.Clients.ActiveDirectory": {
         "type": "Transitive",
@@ -1313,8 +1313,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -1649,8 +1649,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "3qreYFQcLnyFk1LuaNWyyWE+sfkfe5eSTaIIssYrLNUIDbgyZNQBYQSzSDo4AprpjVeVX2T4KHKii9fiSZVUow=="
+        "resolved": "4.7.2",
+        "contentHash": "iTUgB/WtrZ1sWZs84F2hwyQhiRH6QNjQv2DkwrH+WP6RoFga2Q1m3f9/Q7FG8cck8AdHitQkmkXSY8qylcDmuA=="
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -1815,8 +1815,8 @@
       "marain.claims.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Menes.Abstractions": "1.2.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
+          "Menes.Abstractions": "2.0.1",
           "Microsoft.Extensions.FileSystemGlobbing": "3.1.0",
           "Newtonsoft.Json": "12.0.3"
         }

--- a/Solutions/Marain.Claims.Specs/Bindings/ClaimsContainerBindings.cs
+++ b/Solutions/Marain.Claims.Specs/Bindings/ClaimsContainerBindings.cs
@@ -9,6 +9,11 @@ namespace Marain.Claims.SpecFlow.Bindings
     using Corvus.Testing.SpecFlow;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Serialization;
+
     using TechTalk.SpecFlow;
 
     /// <summary>
@@ -40,10 +45,13 @@ namespace Marain.Claims.SpecFlow.Bindings
 
                     serviceCollection.AddLogging();
 
-                    serviceCollection.AddRootTenant();
                     serviceCollection.AddInMemoryTenantProvider();
 
-                    serviceCollection.AddJsonSerializerSettings();
+                    serviceCollection.AddJsonNetSerializerSettingsProvider();
+                    serviceCollection.AddJsonNetPropertyBag();
+                    serviceCollection.AddJsonNetCultureInfoConverter();
+                    serviceCollection.AddJsonNetDateTimeOffsetToIso8601AndUnixTimeConverter();
+                    serviceCollection.AddSingleton<JsonConverter>(new StringEnumConverter(new CamelCaseNamingStrategy()));
 
                     var tenantCloudBlobContainerFactoryOptions = new TenantCloudBlobContainerFactoryOptions
                     {

--- a/Solutions/Marain.Claims.Specs/Marain.Claims.Specs.csproj
+++ b/Solutions/Marain.Claims.Specs/Marain.Claims.Specs.csproj
@@ -40,13 +40,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.5" />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.6" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Idg.AsyncTestTools" Version="1.0.0" />
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.0.1" />
+    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.3.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[3.1.*,)" />

--- a/Solutions/Marain.Claims.Specs/packages.lock.json
+++ b/Solutions/Marain.Claims.Specs/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETCoreApp,Version=v3.1": {
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
-        "requested": "[1.4.5, )",
-        "resolved": "1.4.5",
-        "contentHash": "rGwqPPBbIyhW0x5LeU+JRjLh3YqnCfBKiy7+wIIFoJZCpR7elcKhwNb6WXYI0YZc/v6mUcPjcvQ/1Px0oEZLyg==",
+        "requested": "[1.4.6, )",
+        "resolved": "1.4.6",
+        "contentHash": "N7Vti+2pxUOFphEAh20JAN/ro8h02+TzLRnZaHoI5fEQysw6DPmCHklzWdMADxTTLSwLQ5DsrhZVKTSd7+LHBw==",
         "dependencies": {
-          "Corvus.Testing.SpecFlow": "1.4.5",
+          "Corvus.Testing.SpecFlow": "1.4.6",
           "Microsoft.NET.Test.Sdk": "[16.10.0, 17.0.0)",
           "Moq": "4.16.1",
           "SpecFlow.NUnit.Runners": "3.9.22",
@@ -35,51 +35,50 @@
       },
       "Marain.Services.Tenancy.Testing": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "IAsUx1/U0MHXrG+XRMdUoBl6y7Ix7h43QN+7O+JvuzbYtP+q/LCjTkXD+M9FkzScwrufTKOLJD9Z5mDoBL3pEw==",
+        "requested": "[2.3.3, )",
+        "resolved": "2.3.3",
+        "contentHash": "55SKCDTvN7r3+KLtaFt//16axFajzySRLHDO7s4+k/0xNYQ035Q+jb2T7zdhiO7b0mVq2IiefLHMZBYhe9sU6Q==",
         "dependencies": {
-          "Corvus.SpecFlow.Extensions": "0.6.0",
-          "Marain.TenantManagement.Abstractions": "2.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
-          "SpecFlow": "3.3.30"
+          "Corvus.Testing.SpecFlow": "1.3.2",
+          "Marain.TenantManagement.Abstractions": "2.3.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.13"
         }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "KDfhqlop17pf6zSOzcIydwXNFI8T15Sg7vguGvf9cjPpXCSNSvuWjVpZB+T9KAGQT7mbrB2W0GOYl/1Kgre/7Q==",
+        "resolved": "3.1.20",
+        "contentHash": "qN871hvjHs9pqVW1E8dXzww3hDXmAtSC0Mjvht+2choJN+KKLL/mQpX2Egkp9Wvox005bfmBrFW7svDDTjmuoQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "Fbqktw5CRufEEAYvBBWB6QnuFLLk647RvseItBdnKhp3awiXKpjYgLhv3JH6Ndtj8kdwChcfhHjlcZOk+8EXdw==",
+        "resolved": "3.1.20",
+        "contentHash": "117x0om5ZospcNDoUUwHjA/k8sEjGGE+E1R7B7hwo+ZcaWQtk8scnGWYBahKP9yzLpB11HNs3hlv23sSXToogQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "sUwnSp6N8gpeXiAXFOY4SEAyRoeIvRRzPOOQ9+X2w7TkOQSImBWIA5Ol21GV3WOUqD0vukymu0TZ2WaaPiLW9w==",
+        "resolved": "3.1.20",
+        "contentHash": "sNliq6gPP03/lC6dbtBv5EuMX8bnWBOsSaK6qg/TbPtZIV/i8RwxYWYW0Y+koepeLEVae3wtcUBX7sQfaCw3LQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19",
-          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.20"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.1.*, )",
-        "resolved": "3.1.19",
-        "contentHash": "cdBicT5kRGBVWilW0QUFYmeqYNgBP3NHwrnsuJj0QqivA74OHcUiS18EFLMRmqwZ746mbnptfSZ4Lh997KsUew==",
+        "resolved": "3.1.20",
+        "contentHash": "JAV97hx4y7qJ5mnjnUOSd+xDnMj2+51c8KVirhuU+rOW1LUnsmjhin86Tep6Q5tOHmNPOmmo6OHEFCdbZj5+zw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20"
         }
       },
       "Microsoft.SourceLink.GitHub": {
@@ -152,46 +151,46 @@
       },
       "Corvus.Azure.Cosmos.Tenancy": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "BgD87nmE/DXrE6GVXRKJ8t3DXgeyCuQLJf48xGgfhFmVxkvOOSOPoSxSI4BkcHeZgRTfVUyITOojM4H2XaHs3Q==",
+        "resolved": "2.0.2",
+        "contentHash": "yLJTvsrf5Cg2lQbIpIWMpV56n7b/E2nUz1gWilDtxDvnCAtlo1VUIStHwlFgQ1WnR+RIeyxukOtLCYgs7xFZ7A==",
         "dependencies": {
-          "Corvus.Extensions.CosmosClient": "1.0.5",
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Corvus.Extensions.CosmosClient": "2.0.4",
+          "Corvus.Tenancy.Abstractions": "2.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.13",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.13"
         }
       },
       "Corvus.Azure.Storage.Tenancy": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "frJ6rmdONMMTMd07YXN6GbnhQs+rw9/WWMvG4ThdV8vxTU3v8kCdBcs6SpeaWEksBbWHI5ReOUF+tjKC8gv2Rw==",
+        "resolved": "2.0.13",
+        "contentHash": "naqlx/mpp9OXw0DWQCUMZ93mmyLiLDdk+SSxR9iBMdZXgy/76iO331C5L1Ee24pKizqIq8tmibN35sUr9KN8KA==",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
           "Microsoft.Azure.KeyVault": "3.0.5",
-          "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
-          "Microsoft.Azure.Storage.Blob": "11.2.2",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.12"
+          "Microsoft.Azure.Services.AppAuthentication": "1.6.2",
+          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.20"
         }
       },
       "Corvus.ContentHandling": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "O1CJ5Tfv/dFe9y6IOw0EWTnXvDmZe+8cEV1C1RHOv9NwOvxLdp1lHsngxBtcEV41e1jPMqci1ShzFtFB1Wi14Q==",
+        "resolved": "2.0.11",
+        "contentHash": "W4yuYfITGgwPg8KRFlLurwUp9aAsOggedBbtbLPPSmJTJzDK3BMiJnEJh/j0Rc2P37oqv3j8jhf3aOfvn7s5XQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.8.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12",
+          "Microsoft.CodeAnalysis.CSharp": "3.11.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "System.Runtime.Loader": "4.3.0"
         }
       },
       "Corvus.ContentHandling.Json": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "Nxn2qhw3DqJeX63+TY+PNePqFIwyupocUubsfz70d2Qgk6k66Kx2KBxd5pXotmhQKY2IAw2uxHhWCnGAP/wOVw==",
+        "resolved": "2.0.11",
+        "contentHash": "aYnqiQB7nCe+Pq4szhsdBYRpaXcdZX0u77JL57YAKg/Jfty9p5xVB+9cwi+O7z6boD/xOyYjkr44qMvt06i/ng==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.ContentHandling": "2.0.11",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.5",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -205,13 +204,13 @@
       },
       "Corvus.Extensions.CosmosClient": {
         "type": "Transitive",
-        "resolved": "1.0.5",
-        "contentHash": "uhwd53ei0YTinBU1xX9Ci9xMGzbecfONhia+xdwDK5o7+oCNnA9HRyoSmQfGZ3+VJaWWqYEFVYDSqfARii/u6Q==",
+        "resolved": "2.0.4",
+        "contentHash": "QhX2y2JhofFQMW+6rxGno8VUD8Zd1fd1o0+pPw3/tsTbRGrTVggx8xhJrzRRxuXKTWWobBGMEP2zW8z+1rwLWg==",
         "dependencies": {
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
-          "Corvus.Retry": "1.0.1",
-          "Microsoft.Azure.Cosmos": "3.16.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
+          "Corvus.Retry": "1.0.2",
+          "Microsoft.Azure.Cosmos": "3.17.0",
           "Microsoft.Azure.KeyVault": "3.0.5",
           "Microsoft.Azure.Services.AppAuthentication": "1.6.1",
           "Microsoft.Bcl.HashCode": "1.1.1"
@@ -219,11 +218,11 @@
       },
       "Corvus.Extensions.Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "cgnu26gsI09OO7v9KNkgNpKRiWCD27GFE8R2STjyRgVuIGnDaKP5tQlUh3hQS1Rmw0F0fYGSbRGMdAUCwnVd2A==",
+        "resolved": "2.0.6",
+        "contentHash": "6yXJ7xbflSB3c0G7hdNExwlhbEChMRcSn6fX4k8ghhWyADrDSY6jJp9Ce6guxo1c4gVjZwgCVIDhA3JgO8KyHA==",
         "dependencies": {
-          "Corvus.Json.Abstractions": "1.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
+          "Corvus.Json.Abstractions": "2.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -239,8 +238,8 @@
       },
       "Corvus.Json.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "tkj8QDNAKoemvMGLnIHLiuQiaI8DfKpT8T1snqd9/UYzZeIonjjM/MtaJOq5PP+AB3L2h8ZaFA/sgryJMIxsGw=="
+        "resolved": "2.0.6",
+        "contentHash": "ixx72ttlP/Ck+UMWyfiRWVBFKU5XjJySMG33ZWofJp9yy65VF3uOJyGPujr3OedUMo6Uq9umftmHRqhOmUyQ8g=="
       },
       "Corvus.Monitoring.Instrumentation.Abstractions": {
         "type": "Transitive",
@@ -252,50 +251,27 @@
       },
       "Corvus.Retry": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "aEshkQnOjIJ/F2N0iQHx97A23IeTqqsyIFWBT08gbApr8MUrn8lxpmk5ASpzxCxLUFz+cQiknGbc4etpsorHCA=="
-      },
-      "Corvus.SpecFlow.Extensions": {
-        "type": "Transitive",
-        "resolved": "0.6.0",
-        "contentHash": "N6WWrZ1o9SAiyYwrAH1kFWR9CAOpixybOdAcxEt0BU/hYln/D/oaHUfLJNKBNntA2bv2/kB/aGai9br7uVAI1g==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.2.0",
-          "NUnit": "3.12.0",
-          "SpecFlow": "3.0.225",
-          "System.Management": "4.5.0"
-        }
+        "resolved": "1.0.2",
+        "contentHash": "Jzmv1VpjJnIaz+b0uadkl3yoNh+qnmzHvOcHUXc5oAo1fVqclzxLJAqhOPnm5BVURA5nlqgB3mtmI1YQQhwh9A=="
       },
       "Corvus.Tenancy.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Ooq7Y42DWuX6zJkAADrKUjA9m2O8gVnL8OXVJ79e1qmV/dpA2ek25bfO3PBLKbjuCSGWg2JpwXTd//OKWGhX5A==",
+        "resolved": "2.0.13",
+        "contentHash": "uZxeWtTHYmjI580a+MnrwvgW5KLjhXbDA6o0A5Xo1xPRC3cn2xPXXvfO+ClHtJuyh2bzL8gaWjXyj85N4q5oVg==",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "1.1.0",
-          "Corvus.Extensions": "1.1.2",
-          "Microsoft.Extensions.Primitives": "3.1.12"
-        }
-      },
-      "Corvus.Testing.AzureFunctions": {
-        "type": "Transitive",
-        "resolved": "1.4.5",
-        "contentHash": "cg+Z904qRJr0ZO1zC+kTs4bdJi+HMTFzCNZJB/TR72gZn8nR6HTWUXSsvhjLdtReh3Dc4EKJwq6LErgIXBWlAQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.19",
-          "System.Management": "4.7.0"
+          "Corvus.ContentHandling.Json": "2.0.11",
+          "Corvus.Extensions": "1.1.4",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Corvus.Testing.SpecFlow": {
         "type": "Transitive",
-        "resolved": "1.4.5",
-        "contentHash": "wECzJlyMgoKZv6fI0y69IDs8oZ20FoZ2vluJqg5uID8shy+HmzN86ZG7rKXxZUyqSmszKoNrF23zNrr4v8545w==",
+        "resolved": "1.4.6",
+        "contentHash": "EmakRYEWtLqOXJXV8vOq4bOikivszKcclnRClM65IULefSCY1Cm+pP5wvJusetZWRQ7xXjvI9Hzp25T1MJmVBQ==",
         "dependencies": {
-          "Corvus.Testing.AzureFunctions": "1.4.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "NUnit": "3.13.2",
           "SpecFlow": "3.9.22",
           "System.Management": "4.7.0"
@@ -329,56 +305,56 @@
       },
       "Marain.Services.Tenancy": {
         "type": "Transitive",
-        "resolved": "2.2.2",
-        "contentHash": "6PytV+UCYuhKWGHYeBrOdbQWz0vhZbsFEq0bepCjAi3ULICYhrhPHKYbGsk7Dw/0jgJrLjVp4kGc2LL2uIxymQ==",
+        "resolved": "2.3.3",
+        "contentHash": "Gqo6MqvgdtwCOMeo3gQKk7t1ngDNiBhuF1g0180NUiHQMsxLl8pN0G9p42lKPDL59jbQX573yUgrtE5wU+vLfQ==",
         "dependencies": {
-          "Marain.TenantManagement.Abstractions": "2.2.2",
-          "Menes.Abstractions": "1.2.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.12"
+          "Marain.TenantManagement.Abstractions": "2.3.3",
+          "Menes.Abstractions": "2.0.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.13"
         }
       },
       "Marain.TenantManagement.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.2",
-        "contentHash": "0cEk4QkHeZ7KOy7jLxC45ajbtQb3kGWRI0RUQeoNNPpXJ7sc1QLCFM6yuxOfeJr4uGoGT6/I5TW1r7cpNpOrKQ==",
+        "resolved": "2.3.3",
+        "contentHash": "CBBYF1RSNITOssgphcvUimlkFbn1/7yUXY+iohgapzG3DLAcsfqft6/IPseX+3s4nlL/Mcfsx3hwKbjWMRRiqQ==",
         "dependencies": {
-          "Corvus.Azure.Cosmos.Tenancy": "1.1.1",
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Microsoft.Extensions.Logging": "3.1.12"
+          "Corvus.Azure.Cosmos.Tenancy": "2.0.2",
+          "Corvus.Azure.Storage.Tenancy": "2.0.2",
+          "Corvus.Tenancy.Abstractions": "2.0.2",
+          "Microsoft.Extensions.Logging": "3.1.13"
         }
       },
       "Menes.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "H6Q4P6LVCJzXepyrvFYallQy8refCBOdlp1ymXJxBVkYSX9iQJFYvc0PSUVY6QPLKS9svE59kecVMFpgGgDUcw==",
+        "resolved": "2.0.1",
+        "contentHash": "uNJTJhw3gHx2NYuQUt8YV/UGtPhqzvN+Xh1QWLia0ZmUByNJ19GcDtCE4pPfabnPp2eL23NhJUN7UvhWWeUNog==",
         "dependencies": {
-          "Corvus.ContentHandling": "1.1.0",
+          "Corvus.ContentHandling": "2.0.4",
           "Corvus.Extensions": "1.1.2",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.2",
           "Corvus.Monitoring.Instrumentation.Abstractions": "1.2.0",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Logging": "3.1.12",
+          "Microsoft.Extensions.Logging": "3.1.13",
           "Microsoft.OpenApi.Readers": "1.2.3",
           "System.Interactive": "4.1.1",
-          "System.Text.Encodings.Web": "4.7.1",
+          "System.Text.Encodings.Web": "4.7.2",
           "Tavis.UriTemplates": "1.1.1"
         }
       },
       "Menes.Hosting": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "n82LVUCzHph96w8X7LjQP88Pj2QNFxJ3EmSYLlL7jIgdFdKhHYQqc1NXiLGcLQwLTtfvIxbvpQAxhAlOzPBLJw==",
+        "resolved": "2.0.1",
+        "contentHash": "wRXHxNfI9Bwl7Qnpz74HfZeDNFSjMHBNjXmpn7yuErxtP8ujjGxqZEOdiPPQ457N4prmShbOVPaYtQVdbaXnNw==",
         "dependencies": {
-          "Menes.Abstractions": "1.2.1"
+          "Menes.Abstractions": "2.0.1"
         }
       },
       "Menes.Hosting.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "4a3OAXeVUi+mhB2JeIaRPlqut5QE9CQxol9RiUM7C3SjEMhQDVOZJxJqILIEj/Q59khYzRmLScNira5ECymdmg==",
+        "resolved": "2.0.1",
+        "contentHash": "Zpzf8AHD7BQ7gOBe52Dw+tcZc+eh/7HLrCe9YHkw5PqjaF6SpvMfSpKowSTJLF1p5CVqQIxuNIyITl2/rYTDJQ==",
         "dependencies": {
-          "Menes.Hosting": "1.2.1",
+          "Menes.Hosting": "2.0.1",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Mvc.Core": "2.2.5"
         }
@@ -558,8 +534,8 @@
       },
       "Microsoft.Azure.Cosmos": {
         "type": "Transitive",
-        "resolved": "3.16.0",
-        "contentHash": "8CVDpwJcGlD1ehuKde5Uju0gjeIcDQIq5xmhE8VnrWH1DjzZ3nJ2uGVMqCj7G8XYkxTR9m42E7wREOEbMYF++g==",
+        "resolved": "3.17.0",
+        "contentHash": "SDUIpfOWKiE+RMe9RcaxatmSlzC+MqC0hRInEWqU9n0ntG1M2Hv/0IT5He6LQMe2io59gxUvMHuIZe9Dih8hjw==",
         "dependencies": {
           "Azure.Core": "1.3.0",
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
@@ -648,10 +624,10 @@
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Transitive",
-        "resolved": "1.6.1",
-        "contentHash": "78AcjpxnhJDov7HJa4kPpZxpI0coZhS0tdA9ZLUSPExKz5KTgfozayBTLAXDuTuq0gLRzFyf85SvIkrtbB8KpA==",
+        "resolved": "1.6.2",
+        "contentHash": "rSQhTv43ionr9rWvE4vxIe/i73XR5hoBYfh7UUgdaVOGW1MZeikR9RmgaJhonTylimCcCuJvrU0zXsSIFOsTGw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.0",
+          "Microsoft.IdentityModel.Clients.ActiveDirectory": "5.2.9",
           "System.Diagnostics.Process": "4.3.0"
         }
       },
@@ -691,29 +667,29 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.0.0",
-        "contentHash": "ojG5pGAhTPmjxRGTNvuszO3H8XPZqksDwr9xLd4Ae/JBjZZdl6GuoLk7uLMf+o7yl5wO0TAqoWcEKkEWqrZE5g=="
+        "resolved": "3.3.2",
+        "contentHash": "7xt6zTlIEizUgEsYAIgm37EbdkiMmr6fP6J9pDoKEpiGM4pi32BCPGr/IczmSJI9Zzp0a6HOzpr9OvpMP+2veA=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "8YTZ7GpsbTdC08DITx7/kwV0k4SC6cbBAFqc13cOm5vKJZcEIAh51tNSyGSkWisMgYCr96B2wb5Zri1bsla3+g==",
+        "resolved": "3.11.0",
+        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
           "System.Collections.Immutable": "5.0.0",
           "System.Memory": "4.5.4",
           "System.Reflection.Metadata": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.7.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
           "System.Text.Encoding.CodePages": "4.5.1",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.8.0",
-        "contentHash": "hKqFCUSk9TIMBDjiYMF8/ZfK9p9mzpU+slM73CaCHu4ctfkoqJGHLQhyT8wvrYsIg+ufrUWBF8hcJYmyr5rc5Q==",
+        "resolved": "3.11.0",
+        "contentHash": "aDRRb7y/sXoJyDqFEQ3Il9jZxyUMHkShzZeCRjQf3SS84n2J0cTEi3TbwVZE9XJvAeMJhGfVVxwOdjYBg6ljmw==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.8.0]"
+          "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
       "Microsoft.CodeCoverage": {
@@ -776,33 +752,33 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "5XARAKFFAlX6WVk/c2/oAW44Oh0TMYwIFJJqxjkFXjPWsZAFuPTD0yLuaXvnILATpR8guks4V8yTE33HaV7ZOg==",
+        "resolved": "3.1.20",
+        "contentHash": "TpevBA1qF8XuuP5md8As81SHfhtAsVocH/i76F1WjYoOBpA9nwC3dmpN/YDi89efRzU6qk5AYvZ1ldCONtAYSQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "UmyDTRQWG1RaP70rGlymCWlDKK9ZHvypJocinplxeeky3bevDBdI4qnhT0eXQSu/iRlanXvhoyBimh9glXPJjg==",
+        "resolved": "3.1.20",
+        "contentHash": "eS6Q5oRKmBQKlgIjSXmgaF2jwSAuii+3UjTSN4jI2LH1N0utPNgZNtnOVXDU2tZiUOtQuAROBb8PZKgHgIgsYQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "F8gKoMRJH/jn81sxujNMAmJA65nirCjPACU25wSKaXGMQ4K/aatb5V70hkzsgffsxNI3EvmTEA2u40NBB4RHYg==",
+        "resolved": "3.1.20",
+        "contentHash": "qqfD7VfSDds340cuVggQQGlSoVuMYAtW6UIczf3UKV8CMfnP7CRc9mjlVl4R5/Jovbd5vkl56E6lg03W/ZWCtA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.19",
-          "Microsoft.Extensions.FileProviders.Physical": "3.1.19"
+          "Microsoft.Extensions.Configuration": "3.1.20",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.20"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "tiaohUQoNWfUQBWAW4wg9yRYAYcxq0IERI6bR8DojusFIVybdzOJ1bJXLghfO17cGx05SdiUnUk8h0SiQn0hBw=="
+        "resolved": "3.1.20",
+        "contentHash": "a2axLm7TfsB6rELiYDp7qx0S64h1FCFAFGz0WnPWgyshpvLWYM/XKwLHIPqiXuhtEp9kT4qBXRYsXMe6ZrxX0A=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -818,25 +794,25 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "dl2aT5R9Eq36T3fH0uWPNygApojb4cq4s8+pfFTGJtpy6s8ss4t2vh7Kzi6dr1SC+pgbFkgXLkh8DRl5mqmvLw==",
+        "resolved": "3.1.20",
+        "contentHash": "gR0rfQg7a1DJMlPDRii4fypu/M5tQ/0pf5mGF4jotcTCyT71wCwuONm1IruDJi+rWa4zPBPovRjdGa0Yx4Lxyg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "DZh94lZTqYx2oAuDNckgj28+7gYxjtAOskpSp+2Tu9YKXXgNkFtAKC7QKvpFkGvZK4C3way+R7WI58bIN3aPrw==",
+        "resolved": "3.1.20",
+        "contentHash": "bewykuIeGb6Ro2Vq2/F1rq5jhmCsocDlgEKg2tMThsnfABXjlJbOXyjJl2GztXhtobsDpuOiWH48MM7qSONNtQ==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.19",
-          "Microsoft.Extensions.FileSystemGlobbing": "3.1.19"
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.20",
+          "Microsoft.Extensions.FileSystemGlobbing": "3.1.20"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Htid3HfJu6W5KInQvN31ku2JHU9R0Oy4wlv22M7Paj9x1gjeEx3mhpPVgclnAm/2OCo+b9ZTqwUZD7Mx3lXuBQ=="
+        "resolved": "3.1.20",
+        "contentHash": "2Sz4v3iuv1ZXVxz2/SfdaDVsfbeHirmlFp2zcguyS9IHh2ZxnCzMOLjvmkf+vt/XFRQaIFIDepushHdkif4xsQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -851,19 +827,19 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "3.1.12",
-        "contentHash": "EXwfP6M/G6mwM/f9eVNY3tOnY539gIEjeSXs2G/RtuGILteW455ZLxfZmE7qzWSc0J2wvoMuxdkB+WMsBW8Kqw==",
+        "resolved": "3.1.13",
+        "contentHash": "CjerR5jL1J3lxjFrrqaw+p8uIK95gulacGKOgMoYSpaF5QB9TISYE8R2WUvVOxa2n0LxQpp9cvVoFof5JAg5ow==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Binder": "3.1.12",
-          "Microsoft.Extensions.DependencyInjection": "3.1.12",
-          "Microsoft.Extensions.Logging.Abstractions": "3.1.12",
-          "Microsoft.Extensions.Options": "3.1.12"
+          "Microsoft.Extensions.Configuration.Binder": "3.1.13",
+          "Microsoft.Extensions.DependencyInjection": "3.1.13",
+          "Microsoft.Extensions.Logging.Abstractions": "3.1.13",
+          "Microsoft.Extensions.Options": "3.1.13"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "ZJxpOfelPknOpD+/P+vcvXXAo7JVwBu2n/NkTuQzwneVzqJFzXB4lJu/jr4sbMIrTNvJi/XixPHrKcaztVkXSQ=="
+        "resolved": "3.1.20",
+        "contentHash": "pejtJ+FM3tRm9Ssy9VO1PMkxlpkwbO+iQmK/Ot9DqgW3zjeLSQg3bEPI6klU70yoRSDwpiI8E71RdzU+vn/bTQ=="
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
@@ -872,39 +848,40 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "awGsLKbgxb/3jxmKQQpD2aPAsWW//d8MTQfFB2XgU2xnjLCx+GN5EPdLe6GfB9ulMq/2AiqZ3IXciHBzSGQ1Uw==",
+        "resolved": "3.1.20",
+        "contentHash": "K5h3xUrYP8mbGZeGAm/vcWjol2wBh2V1vV+Vz02DCKlZ/99Y8ecKJwdpH+elfdqcEFXy76jk+I1nBsmhPKeCgw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Primitives": "3.1.19"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Primitives": "3.1.20"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "wcPJBm5oKhGLYoTzN8CQIDrLvDCAHxI5JZXQbHNcsKmuc5JYO+I/iTGqnJ7UPw40HI4YhvsnwooeMsJZdHQGWg==",
+        "resolved": "3.1.20",
+        "contentHash": "vmh27AY00NDg6+4P5NbLnhKsrNMBtfcFAoE0Pim7yNAB46ev44vu2O5a3AINUoRl9Kovik72Wgn8qA4IpQu+vg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Configuration.Binder": "3.1.19",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.19",
-          "Microsoft.Extensions.Options": "3.1.19"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Configuration.Binder": "3.1.20",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Options": "3.1.20"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "3.1.19",
-        "contentHash": "Al3SuZLS4nN7o3TQPfJGHNnQuLEKXz/tBXoPeESMnJxRLCWomo9MAdjEBunexaWK4as+ESVqOD2rLVyBBx3/qA=="
+        "resolved": "3.1.20",
+        "contentHash": "RHHWUHzW8y+dyNBIBmo2EQbpCC6xFQcFMpLhNcpzw3zP0rxJdhmTTdy5eXvhlkNi3vqM4Af5Qqb5xgYwqaoaJQ=="
       },
       "Microsoft.IdentityModel.Clients.ActiveDirectory": {
         "type": "Transitive",
-        "resolved": "5.2.0",
-        "contentHash": "5zCom0plcWSAuPp2B/Fo7XFKdrPUOaE+1dhVW5Ui2Gny7YYv1fDJ1Z8GeZEJuCd3rKN4UBO834wPEhU5gIPQMw==",
+        "resolved": "5.2.9",
+        "contentHash": "WhBAG/9hWiMHIXve4ZgwXP3spRwf7kFFfejf76QA5BvumgnPp8iDkDCiJugzAcpW1YaHB526z1UVxHhVT1E5qw==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0",
           "NETStandard.Library": "1.6.1",
           "System.ComponentModel.TypeConverter": "4.3.0",
           "System.Dynamic.Runtime": "4.3.0",
           "System.Net.Http": "4.3.4",
+          "System.Private.Uri": "4.3.2",
           "System.Runtime.Serialization.Formatters": "4.3.0",
           "System.Runtime.Serialization.Json": "4.3.0",
           "System.Runtime.Serialization.Primitives": "4.3.0",
@@ -939,8 +916,8 @@
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+        "resolved": "1.1.3",
+        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
       },
       "Microsoft.OData.Core": {
         "type": "Transitive",
@@ -1046,8 +1023,8 @@
       },
       "NETStandard.Library": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "7jnbRU+L08FXKMxqUflxEXtVymWvNOrS8yHgu9s6EM8Anr6T/wIX4nZ08j/u3Asz+tCufp3YVwFSEvFTPYmBPA==",
+        "resolved": "2.0.1",
+        "contentHash": "oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -1892,6 +1869,15 @@
           "System.Xml.XmlSerializer": "4.3.0"
         }
       },
+      "System.Private.Uri": {
+        "type": "Transitive",
+        "resolved": "4.3.2",
+        "contentHash": "o1+7RJnu3Ik3PazR7Z7tJhjPdE000Eq2KGLLWhqJJKXj04wrS8lwb1OFtDF9jzXXADhUuZNJZlPc98uwwqmpFA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
       "System.Reflection": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1998,8 +1984,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -2340,8 +2326,8 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "3qreYFQcLnyFk1LuaNWyyWE+sfkfe5eSTaIIssYrLNUIDbgyZNQBYQSzSDo4AprpjVeVX2T4KHKii9fiSZVUow=="
+        "resolved": "4.7.2",
+        "contentHash": "iTUgB/WtrZ1sWZs84F2hwyQhiRH6QNjQv2DkwrH+WP6RoFga2Q1m3f9/Q7FG8cck8AdHitQkmkXSY8qylcDmuA=="
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -2534,8 +2520,8 @@
       "marain.claims.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Tenancy.Abstractions": "1.1.1",
-          "Menes.Abstractions": "1.2.1",
+          "Corvus.Tenancy.Abstractions": "2.0.13",
+          "Menes.Abstractions": "2.0.1",
           "Microsoft.Extensions.FileSystemGlobbing": "3.1.0",
           "Newtonsoft.Json": "12.0.3"
         }
@@ -2558,9 +2544,9 @@
       "marain.claims.openapi.service": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
           "Marain.Claims.Abstractions": "1.0.0",
-          "Marain.Services.Tenancy": "2.2.2",
+          "Marain.Services.Tenancy": "2.3.3",
           "Microsoft.ApplicationInsights": "2.18.0",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.0"
@@ -2570,7 +2556,7 @@
         "type": "Project",
         "dependencies": {
           "Corvus.Extensions": "1.1.4",
-          "Corvus.Extensions.Newtonsoft.Json": "1.2.0",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.6",
           "Marain.Claims.Abstractions": "1.0.0",
           "Microsoft.Azure.Storage.Blob": "11.2.3"
         }
@@ -2578,10 +2564,10 @@
       "marain.claims.tenancy.azureblob": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Azure.Storage.Tenancy": "1.1.1",
+          "Corvus.Azure.Storage.Tenancy": "2.0.13",
           "Marain.Claims.OpenApi": "1.0.0",
           "Marain.Claims.Storage.AzureBlob": "1.0.0",
-          "Menes.Hosting.AspNetCore": "1.2.1",
+          "Menes.Hosting.AspNetCore": "2.0.1",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "3.1.0"
         }

--- a/Solutions/Marain.Claims.Storage.AzureBlob/Marain.Claims.Storage.AzureBlob.csproj
+++ b/Solutions/Marain.Claims.Storage.AzureBlob/Marain.Claims.Storage.AzureBlob.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Extensions" Version="1.1.4" />
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="1.2.0" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="2.0.6" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Marain.Claims.Tenancy.AzureBlob/Marain.Claims.Tenancy.AzureBlob.csproj
+++ b/Solutions/Marain.Claims.Tenancy.AzureBlob/Marain.Claims.Tenancy.AzureBlob.csproj
@@ -18,12 +18,12 @@
     </PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="1.1.1" />
+    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="2.0.13" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Menes.Hosting.AspNetCore" Version="1.2.1" />
+    <PackageReference Include="Menes.Hosting.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.*,)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[3.1.*,)" />
   </ItemGroup>


### PR DESCRIPTION
This upgrades various Corvus package major versions. However, this is not the full set of changes planned for #294 - we're still on the old Azure SDK, and will need the new bits coming in `Corvus.Storage` v1, and `Corvus.Tenancy` v3. This is just to get us back in line with current versions in the mean time.