### PR TITLE
Remove some build.ps1 hacks

### DIFF
--- a/Solutions/Marain.Claims.sln
+++ b/Solutions/Marain.Claims.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DevOps", "DevOps", "{D29CABE7-467E-4CF6-B44B-3C58AB76145A}"
 	ProjectSection(SolutionItems) = preProject
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
+		..\build.ps1 = ..\build.ps1
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject

--- a/build.ps1
+++ b/build.ps1
@@ -132,18 +132,7 @@ task . FullBuild
 
 
 # build extensibility tasks
-task PostVersion {
-    # Should be these, but Endjin.RecommendedPractices.Build beta008 is not adding the GITVERSION_ prefix
-    # ...ah...except that's only going wrong for Azure DevOps tasks downstream of us. Within the
-    # build.ps1 task, it does work because the environment variable names are correct.
-    Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))))"
-    Write-Host "##vso[task.setvariable variable=Endjin_Repository_Name]$Env:BUILD_REPOSITORY_NAME"
-    # Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($Env:PRERELEASETAG))))"
-    # Write-Host "##vso[task.setvariable variable=Endjin_Repository_Name]$Env:BUILD_REPOSITORY_NAME"
-
-    # Scripted build currently doesn't do this for us.
-    Write-Host "##vso[build.updatebuildnumber]$Env:GITVERSION_SemVer"
-}
+task PostVersion { }
 task PreBuild {}
 task PostBuild {}
 task PreTest {}


### PR DESCRIPTION
Now that the pipeline template does the right things for us, we can drop a bunch of hacks from our build.ps1 file.