### PR TITLE
Put more settings under host application's control

### DIFF
--- a/Solutions/Marain.Claims.OpenApi.Specs/Bindings/FunctionsContainerBindings.cs
+++ b/Solutions/Marain.Claims.OpenApi.Specs/Bindings/FunctionsContainerBindings.cs
@@ -61,6 +61,7 @@ namespace Marain.Claims.OpenApi.Specs.Bindings
                     services.AddSingleton(tenancyClientConfiguration);
                     services.AddTenantProviderServiceClient();
 
+                    services.AddTenantedClaimsStoreOnAzureBlobStorage();
                     services.AddTenantedClaimsApiWithOpenApiActionResultHosting(root);
 
                     services.AddClaimsClient(_ =>

--- a/Solutions/Marain.Claims.OpenApi/Marain/Claims/OpenApi/Internal/ClaimsServiceCollectionExtensions.cs
+++ b/Solutions/Marain.Claims.OpenApi/Marain/Claims/OpenApi/Internal/ClaimsServiceCollectionExtensions.cs
@@ -13,7 +13,8 @@ namespace Marain.Claims.OpenApi.Internal
     public static class ClaimsServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds the request claims provider.
+        /// Adds a request claims provider that uses all registered <see cref="IClaimsProviderStrategy{TRequest}"/>
+        /// to build a claims principal.
         /// </summary>
         /// <typeparam name="TRequest">The type of the request.</typeparam>
         /// <param name="services">The service collection to add to.</param>
@@ -30,7 +31,7 @@ namespace Marain.Claims.OpenApi.Internal
         }
 
         /// <summary>
-        /// Adds a strategy for the claims provider.
+        /// Adds a claims provider strategy for.
         /// </summary>
         /// <typeparam name="TRequest">The type of the request.</typeparam>
         /// <typeparam name="TStrategy">Type of the <see cref="IClaimsProviderStrategy{TRequest}"/> to add.</typeparam>

--- a/Solutions/Marain.Claims.Specs/Bindings/ClaimsContainerBindings.cs
+++ b/Solutions/Marain.Claims.Specs/Bindings/ClaimsContainerBindings.cs
@@ -56,7 +56,7 @@ namespace Marain.Claims.SpecFlow.Bindings
                     serviceCollection.AddBlobContainerV2ToV3Transition();
                     serviceCollection.AddAzureBlobStorageClientSourceFromDynamicConfiguration();
 
-                    serviceCollection.AddTenantedBlobContainerClaimsStore();
+                    serviceCollection.AddTenantedClaimsStoreOnAzureBlobStorage();
 
                     serviceCollection.AddMarainServiceConfiguration();
                     serviceCollection.AddMarainServicesTenancy();

--- a/Solutions/Marain.Claims.Tenancy.AzureBlob/Microsoft/Extensions/DependencyInjection/TenantedBlobStorageClaimsServiceCollectionExtensions.cs
+++ b/Solutions/Marain.Claims.Tenancy.AzureBlob/Microsoft/Extensions/DependencyInjection/TenantedBlobStorageClaimsServiceCollectionExtensions.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Extensions.DependencyInjection
     using Marain.Claims;
     using Marain.Claims.Internal;
 
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Serialization;
+
     /// <summary>
     /// Service collection extensions to add implementations of claims stores.
     /// </summary>
@@ -24,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>
         /// The configured <see cref="IServiceCollection"/>.
         /// </returns>
-        public static IServiceCollection AddTenantedBlobContainerClaimsStore(
+        public static IServiceCollection AddTenantedClaimsStoreOnAzureBlobStorage(
             this IServiceCollection services)
         {
             if (services.Any(s => s.ServiceType is IPermissionsStoreFactory))
@@ -37,6 +41,15 @@ namespace Microsoft.Extensions.DependencyInjection
                 contentFactory.RegisterTransientContent<ResourceAccessRuleSet>();
                 contentFactory.RegisterTransientContent<ClaimPermissions>();
             });
+
+            services.AddBlobContainerV2ToV3Transition();
+            services.AddAzureBlobStorageClientSourceFromDynamicConfiguration();
+
+            services.AddJsonNetSerializerSettingsProvider();
+            services.AddJsonNetPropertyBag();
+            services.AddJsonNetCultureInfoConverter();
+            services.AddJsonNetDateTimeOffsetToIso8601AndUnixTimeConverter();
+            services.AddSingleton<JsonConverter>(new StringEnumConverter(new CamelCaseNamingStrategy()));
 
             services.AddSingleton<IPermissionsStoreFactory, BlobContainerPermissionsStoreFactory>();
 


### PR DESCRIPTION
These were previously baked into the claims service DI init method, but are likely to want to be different for different hosts. (An experimental Service Fabric host was what led to these being identified.)

* Choice of claims provider strategies
* Instrumentation mechanisms
* Service identity configuration
* Claims store mechanism

Also moved serialization initialization code out of service DI init and into storage DI init because that's what needs it.

Improved a few doc comments around the changes.