### PR TITLE
Remove redundant source link references

### DIFF
--- a/Solutions/Marain.Claims.Abstractions/Marain.Claims.Abstractions.csproj
+++ b/Solutions/Marain.Claims.Abstractions/Marain.Claims.Abstractions.csproj
@@ -22,11 +22,4 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Solutions/Marain.Claims.Client.OpenApi/Marain.Claims.Client.OpenApi.csproj
+++ b/Solutions/Marain.Claims.Client.OpenApi/Marain.Claims.Client.OpenApi.csproj
@@ -23,11 +23,4 @@
     <ProjectReference Include="..\Marain.Claims.OpenApi\Marain.Claims.OpenApi.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Solutions/Marain.Claims.Client/Marain.Claims.Client.csproj
+++ b/Solutions/Marain.Claims.Client/Marain.Claims.Client.csproj
@@ -31,11 +31,4 @@
     <PackageReference Include="Cimpress.Extensions.Http.Caching.InMemory" Version="2.1.111" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain.Claims.OpenApi.AspNetCore.csproj
+++ b/Solutions/Marain.Claims.OpenApi.AspNetCore/Marain.Claims.OpenApi.AspNetCore.csproj
@@ -31,11 +31,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Marain.Claims.OpenApi\Marain.Claims.OpenApi.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/Solutions/Marain.Claims.OpenApi.Specs/Marain.Claims.OpenApi.Specs.csproj
+++ b/Solutions/Marain.Claims.OpenApi.Specs/Marain.Claims.OpenApi.Specs.csproj
@@ -54,13 +54,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="ServiceManifests\" />
   </ItemGroup>
 

--- a/Solutions/Marain.Claims.OpenApi/Marain.Claims.OpenApi.csproj
+++ b/Solutions/Marain.Claims.OpenApi/Marain.Claims.OpenApi.csproj
@@ -22,11 +22,4 @@
     <ProjectReference Include="..\Marain.Claims.Abstractions\Marain.Claims.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Solutions/Marain.Claims.Storage.AzureBlob/Marain.Claims.Storage.AzureBlob.csproj
+++ b/Solutions/Marain.Claims.Storage.AzureBlob/Marain.Claims.Storage.AzureBlob.csproj
@@ -25,11 +25,4 @@
     <ProjectReference Include="..\Marain.Claims.Abstractions\Marain.Claims.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/Solutions/Marain.Claims.Tenancy.AzureBlob/Marain.Claims.Tenancy.AzureBlob.csproj
+++ b/Solutions/Marain.Claims.Tenancy.AzureBlob/Marain.Claims.Tenancy.AzureBlob.csproj
@@ -32,10 +32,4 @@
     <ProjectReference Include="..\Marain.Claims.OpenApi\Marain.Claims.OpenApi.csproj" />
     <ProjectReference Include="..\Marain.Claims.Storage.AzureBlob\Marain.Claims.Storage.AzureBlob.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
No longer needed due to Endjin.RecommendedPractices

These should have gone in the previous PR but for some reason none of these were visible in the NuGet package UI in VS.